### PR TITLE
fix(build): use gcr.io/distroless/java17-debian12 as default distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=eclipse-temurin:17-jre-alpine
+ARG BASE_IMAGE=gcr.io/distroless/java17-debian12
 FROM ${BASE_IMAGE}
 
 EXPOSE 8080
 
 COPY target/*.jar /usr/share/app.jar
 
-CMD ["java", "-jar", "/usr/share/app.jar"]
+ENTRYPOINT ["/usr/bin/java", "-jar"]
+CMD ["/usr/share/app.jar"]


### PR DESCRIPTION
This should fix locale issues first reported in SDDHEI-7900 after switching to our internal distroless image.

Distroless images from Google contain locale support and test this during the image build process.
see: https://github.com/GoogleContainerTools/distroless/commit/7c84e8275d06b621ab773abade54dd30f81ed513

Note that previously the image set by default in the Dockerfile was not actually used. Instead an environment variable was set that referenced an internal Distroless image. The variable has been removed to test this PR.