### PR TITLE
Fix/tracing query proneness

### DIFF
--- a/src/main/java/jumper/config/TracingConfiguration.java
+++ b/src/main/java/jumper/config/TracingConfiguration.java
@@ -69,7 +69,7 @@ public class TracingConfiguration {
             gatewayContext.setContextualName("outgoing request: provider");
             gatewayContext.addHighCardinalityKeyValue(
                 KeyValue.of(
-                    "http.url",
+                    "http.uri",
                     filterQueryParams(request.getURI().toString(), compiledQueryFilterPatterns)));
 
             gatewayContext.removeLowCardinalityKeyValue("spring.cloud.gateway.route.id");


### PR DESCRIPTION
when partially encoded query params reach jumper, an illegalargumentexception will be thrown, even it is just for filtering span tags.

we need to
- be prone to partially encoded query params when filtering out spec params for tracing
- go back to overwrite http.uri tag with filtered result from query params