### PR TITLE
fix(security): allow additional url encoded characters

### DIFF
--- a/src/main/java/jumper/config/SecurityConfiguration.java
+++ b/src/main/java/jumper/config/SecurityConfiguration.java
@@ -49,6 +49,10 @@ public class SecurityConfiguration {
     StrictServerWebExchangeFirewall firewall = new StrictServerWebExchangeFirewall();
     firewall.setAllowSemicolon(true);
     firewall.setAllowUrlEncodedSlash(true);
+    firewall.setAllowUrlEncodedDoubleSlash(true);
+    firewall.setAllowUrlEncodedPercent(true);
+    firewall.setAllowUrlEncodedPeriod(true);
+
     return firewall;
   }
 

--- a/src/test/java/jumper/BaseSteps.java
+++ b/src/test/java/jumper/BaseSteps.java
@@ -423,6 +423,11 @@ public class BaseSteps {
         uri += "/path/2003%3A0%3A1903%3Aa6ff%3A%3A60%2F124";
         mockUpstreamServer.testEndpoint(id, "/path/2003%3A0%3A1903%3Aa6ff%3A%3A60%2F124");
         break;
+      case "encodedDoubleSlashesInParameter":
+        setBasePathHeader("/base");
+        uri += "/path/test%2F%2Fvalue";
+        mockUpstreamServer.testEndpoint(id, "/path/test%2F%2Fvalue");
+        break;
       default:
         fail("scenario not defined");
     }

--- a/src/test/resources/features/pathHandling.feature
+++ b/src/test/resources/features/pathHandling.feature
@@ -107,3 +107,9 @@ Feature: proper routingPath and token requestPath is used for provider call
     When consumer calls the proxy route with encodedSlashesAndColonsInParameter
     And API consumer receives a 200 status code
     And verify request has been received
+
+  Scenario: Consumer calls proxy route with URL encoded double slashes in parameter
+    Given RealRoute headers are set
+    When consumer calls the proxy route with encodedDoubleSlashesInParameter
+    And API consumer receives a 200 status code
+    And verify request has been received


### PR DESCRIPTION
Configures the StrictServerWebExchangeFirewall to additionally allow URL-encoded double slashes, percent signs and period characters. These are likely to come up in query params for regular business applications.

Characters like CR/LF, non printable ASCII characters and unnormalized URLs containing plain path traversal sequences (e.g. ../) will still be rejected for increased security.

Refs: SDDHEI-8870