### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: REUSE
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/telekom/gateway-jumper/security/code-scanning/10](https://github.com/telekom/gateway-jumper/security/code-scanning/10)

In general, fix this by explicitly specifying a minimal `permissions:` block either at the workflow root (applies to all jobs) or inside the specific job. For a linting/check workflow that only needs to read the code (checkout + analysis), `contents: read` is an appropriate baseline.

For this specific workflow, the least intrusive change is to add a top-level `permissions:` block directly under `name: REUSE`. This will apply to `lint-reuse` and any future jobs unless they override it, and it avoids altering existing functionality because both `actions/checkout` and `fsfe/reuse-action` only need read access to repository contents. No additional imports or dependencies are needed.

Concretely, edit `.github/workflows/reuse.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 5 (`name: REUSE`). No other regions of the file need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
