### PR TITLE
fix: remove cache for loading the private key

### DIFF
--- a/src/main/java/jumper/Application.java
+++ b/src/main/java/jumper/Application.java
@@ -6,8 +6,10 @@ package jumper;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class Application {
 
   public static void main(String[] args) {

--- a/src/main/java/jumper/job/RedisHealthCheck.java
+++ b/src/main/java/jumper/job/RedisHealthCheck.java
@@ -14,7 +14,6 @@ import org.springframework.data.redis.connection.RedisClusterConnection;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisConnectionUtils;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -22,7 +21,6 @@ import org.springframework.util.Assert;
 @Slf4j
 @ConditionalOnBean(RedisConfig.class)
 @Component
-@EnableScheduling
 public class RedisHealthCheck {
 
   private static final String CONNECT = "CONNECTED";

--- a/src/main/java/jumper/service/KeyInfoService.java
+++ b/src/main/java/jumper/service/KeyInfoService.java
@@ -4,17 +4,24 @@
 
 package jumper.service;
 
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import jumper.model.config.KeyInfo;
 import jumper.util.RsaUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,19 +38,53 @@ public class KeyInfoService {
   @Value("${jumper.security.kid-file}")
   private final String kidFile;
 
-  @Cacheable(value = "cache-key-info", cacheManager = "caffeineCacheManager")
-  public KeyInfo getKeyInfo() throws IOException, GeneralSecurityException {
-    String kid = getKid();
-    PrivateKey privateKey = RsaUtils.getPrivateKey(Path.of(path, keyFile));
+  private final MeterRegistry meterRegistry;
 
-    KeyInfo keyInfo = new KeyInfo();
-    keyInfo.setKid(kid);
-    keyInfo.setPk(privateKey);
+  private final AtomicReference<KeyInfo> keyInfoRef = new AtomicReference<>();
+  private final AtomicInteger keyInfoLoadStatus = new AtomicInteger(0);
+  private final AtomicLong lastEventTimestamp = new AtomicLong(0);
 
-    return keyInfo;
+  @PostConstruct
+  public void init() {
+    keyInfoRef.set(loadKeyInfo());
+    Gauge.builder("jumper.keyinfo.load.status", () -> keyInfoLoadStatus)
+        .description("KeyInfo load status (1=success, 0=failure)")
+        .register(meterRegistry);
+    Gauge.builder("jumper.keyinfo.load.last.timestamp", () -> lastEventTimestamp)
+        .description("KeyInfo Unix timestamp of last update in seconds")
+        .register(meterRegistry);
   }
 
-  private String getKid() throws IOException {
-    return Files.readString(Path.of(path, kidFile));
+  @Scheduled(fixedRateString = "${jumper.security.key-refresh-interval-ms}")
+  public void refresh() {
+    log.info("Refreshing KeyInfo from disk");
+    keyInfoRef.set(loadKeyInfo());
+  }
+
+  public KeyInfo getKeyInfo() {
+    return keyInfoRef.get();
+  }
+
+  private KeyInfo loadKeyInfo() {
+    lastEventTimestamp.set(Instant.now().getEpochSecond());
+    try {
+      String kid = Files.readString(Path.of(path, kidFile));
+      PrivateKey privateKey = RsaUtils.getPrivateKey(Path.of(path, keyFile));
+      KeyInfo keyInfo = new KeyInfo();
+      keyInfo.setKid(kid);
+      keyInfo.setPk(privateKey);
+      log.debug("KeyInfo loaded successfully, kid={}", kid);
+      keyInfoLoadStatus.set(1);
+      lastEventTimestamp.set(System.currentTimeMillis());
+      return keyInfo;
+    } catch (IOException | GeneralSecurityException e) {
+      keyInfoLoadStatus.set(0);
+      KeyInfo existing = keyInfoRef.get();
+      if (existing != null) {
+        log.error("Failed to refresh KeyInfo, keeping existing key", e);
+        return existing;
+      }
+      throw new IllegalStateException("Failed to load KeyInfo on startup", e);
+    }
   }
 }

--- a/src/main/java/jumper/service/TokenGeneratorService.java
+++ b/src/main/java/jumper/service/TokenGeneratorService.java
@@ -6,8 +6,6 @@ package jumper.service;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.WeakKeyException;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.*;
 import jumper.Constants;
 import jumper.model.config.JumperConfig;
@@ -30,19 +28,8 @@ public class TokenGeneratorService {
 
   private String fromRealm(
       HashMap<String, String> claims, String issuer, Date expiration, Date issuedAt) {
-    KeyInfo keyInfo;
-    try {
-      log.debug("GatewayToken or OneToken: Loading keyInfo");
-      keyInfo = keyInfoService.getKeyInfo();
-
-    } catch (IOException e1) {
-      log.error("IOException", e1);
-      throw new RuntimeException("Error while generating LMS token", e1);
-    } catch (GeneralSecurityException e2) {
-      log.error("GeneralSecurityException", e2);
-      throw new RuntimeException("Could not create PrivateKey from key file", e2);
-    }
-
+    log.debug("GatewayToken or OneToken: Loading keyInfo");
+    KeyInfo keyInfo = keyInfoService.getKeyInfo();
     return generateToken(claims, issuer, expiration, issuedAt, keyInfo);
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,12 +37,14 @@ management:
 
 cache-manager:
   caffeine-caches:
-    - cache-names: [ cache-key-info ]
-      spec: maximumSize=1, expireAfterWrite=1m
     - cache-names: [ cache-token-info ]
       spec: maximumSize=${jumper.tokencache.maxSize:10000}, expireAfterWrite=${jumper.tokencache.expireAfterWriteMinutes:30}m
 
 spring:
+  task:
+    scheduling:
+      pool:
+        size: 2
   cache:
     type: caffeine
   lifecycle:
@@ -143,6 +145,7 @@ jumper:
     dir: /keypair
     pk-file: tls.key
     kid-file: tls.kid
+    key-refresh-interval-ms: 60000
     tls:
       additional-allowed-cipher-suites: [ ]
       default-allowed-cipher-suites:

--- a/src/test/java/jumper/config/TlsHardeningConfigurationTest.java
+++ b/src/test/java/jumper/config/TlsHardeningConfigurationTest.java
@@ -16,8 +16,10 @@ import javax.net.ssl.SSLEngine;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class TlsHardeningConfigurationTest {
 
   @Autowired private TlsHardeningConfiguration tlsHardeningConfiguration;

--- a/src/test/java/jumper/regression/GatewayForwardRepoApplicationTest.java
+++ b/src/test/java/jumper/regression/GatewayForwardRepoApplicationTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.web.client.RestClient;
@@ -27,6 +28,7 @@ import org.springframework.web.client.RestClient;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = "spring.main.cloud-platform=kubernetes")
+@ActiveProfiles("test")
 @Import(CloudXForwardedConfiguration.class)
 public class GatewayForwardRepoApplicationTest {
 

--- a/src/test/java/jumper/service/KeyInfoServiceTest.java
+++ b/src/test/java/jumper/service/KeyInfoServiceTest.java
@@ -6,6 +6,8 @@ package jumper.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import jumper.model.config.KeyInfo;
@@ -15,10 +17,14 @@ import org.junit.jupiter.api.Test;
 class KeyInfoServiceTest {
 
   private KeyInfoService testInstance;
+  private MeterRegistry meterRegistry;
 
   @BeforeEach
   void setUp() {
-    testInstance = new KeyInfoService("src/test/resources/keypair", "tls.key", "tls.kid");
+    meterRegistry = new SimpleMeterRegistry();
+    testInstance =
+        new KeyInfoService("src/test/resources/keypair", "tls.key", "tls.kid", meterRegistry);
+    testInstance.init();
   }
 
   @Test
@@ -30,5 +36,13 @@ class KeyInfoServiceTest {
     assertThat(keyInfo).isNotNull();
     assertThat(keyInfo.getKid()).isEqualTo("f47ac10b-58cc-4372-a567-0e02b2c3d479");
     assertThat(keyInfo.getPk()).isNotNull();
+  }
+
+  @Test
+  void shouldRegisterMetricForSuccessfulLoad() {
+    // then
+    assertThat(meterRegistry.find("jumper.keyinfo.load.status").gauge()).isNotNull();
+    assertThat(meterRegistry.find("jumper.keyinfo.load.status").gauge().value()).isEqualTo(1.0);
+    assertThat(meterRegistry.find("jumper.keyinfo.load.last.timestamp").gauge()).isNotNull();
   }
 }


### PR DESCRIPTION
It's better to load the private key and Kid at startup and do refresh with a separate scheduler. That way we do not have cache miss for requests and also do not block the even loop thread
Also set spring.task.scheduling.pool.size to 2, so the two existing Schedulers for 1) update key files 2) redis connection check do not block each other