### PR TITLE
ci(ospo): switch to ospo token defined in the organization

### DIFF
--- a/.github/ort/config.yml
+++ b/.github/ort/config.yml
@@ -36,7 +36,7 @@ ort:
           httpFileStorage:
             url: "https://artifactory.devops.telekom.de/artifactory/open-source-dtit-ort-generic/ort/scan-results"
             headers:
-              Authorization: "Bearer ${ORT_ARTIFACTORY_TOKEN}"
+              Authorization: "Bearer ${OSPO_ORT_ARTIFACTORY_CACHE_REPO_KEY}"
       # ClearlyDefined is disabled because it only produces 404s...
     storageReaders: ["local", "artifactory"]
     storageWriters: ["artifactory", "local"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ name: Build
 #
 # Required secrets:
 # - REGISTRY_TOKEN: Container registry token/password
-# - ORT_ARTIFACTORY_TOKEN: Token for accessing ORT repository
+# - OSPO_ORT_ARTIFACTORY_CACHE_REPO_KEY: Token for accessing ORT repository
 
 on:
   pull_request:

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           fail-on: violations
           docker-cli-args: >-
-            -e ORT_ARTIFACTORY_TOKEN=${{ secrets.ORT_ARTIFACTORY_TOKEN }}
+            -e OSPO_ORT_ARTIFACTORY_CACHE_REPO_KEY=${{ secrets.OSPO_ORT_ARTIFACTORY_CACHE_REPO_KEY }}
           run: >
             cache-dependencies,
             cache-scan-results,


### PR DESCRIPTION
Switch to ospo token defined in the organization, so we do not have to declare the variable in each project separately