### PR TITLE
Feature/warmup component

### DIFF
--- a/src/main/java/jumper/config/WarmupProperties.java
+++ b/src/main/java/jumper/config/WarmupProperties.java
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.config;
+
+import java.time.Duration;
+import java.util.List;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "jumper.warmup")
+@Data
+public class WarmupProperties {
+
+  private boolean enabled = true;
+  private Duration timeout = Duration.ofSeconds(15);
+  private List<String> urls = List.of();
+}

--- a/src/main/java/jumper/config/WarmupProperties.java
+++ b/src/main/java/jumper/config/WarmupProperties.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 @Data
 public class WarmupProperties {
 
-  private boolean enabled = true;
+  private boolean enabled = false;
   private Duration timeout = Duration.ofSeconds(15);
   private List<String> urls = List.of();
 }

--- a/src/main/java/jumper/config/WarmupProperties.java
+++ b/src/main/java/jumper/config/WarmupProperties.java
@@ -17,5 +17,6 @@ public class WarmupProperties {
 
   private boolean enabled = false;
   private Duration timeout = Duration.ofSeconds(15);
+  private int iterations = 1;
   private List<String> urls = List.of();
 }

--- a/src/main/java/jumper/health/WarmupHealthIndicator.java
+++ b/src/main/java/jumper/health/WarmupHealthIndicator.java
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.health;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import jumper.config.WarmupProperties;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(
+    prefix = "jumper.warmup",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WarmupHealthIndicator implements HealthIndicator {
+
+  private final AtomicBoolean ready = new AtomicBoolean(false);
+
+  public WarmupHealthIndicator(WarmupProperties warmupProperties) {
+    // If no URLs configured, skip warmup and report ready immediately
+    if (warmupProperties.getUrls() == null || warmupProperties.getUrls().isEmpty()) {
+      ready.set(true);
+    }
+  }
+
+  @Override
+  public Health health() {
+    if (ready.get()) {
+      return Health.up().build();
+    }
+    return Health.down().withDetail("reason", "warmup in progress").build();
+  }
+
+  public void setReady() {
+    ready.set(true);
+  }
+
+  public boolean isReady() {
+    return ready.get();
+  }
+}

--- a/src/main/java/jumper/health/WarmupHealthIndicator.java
+++ b/src/main/java/jumper/health/WarmupHealthIndicator.java
@@ -7,17 +7,18 @@ package jumper.health;
 import java.util.concurrent.atomic.AtomicBoolean;
 import jumper.config.WarmupProperties;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.ReactiveHealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 @Component
 @ConditionalOnProperty(
     prefix = "jumper.warmup",
     name = "enabled",
     havingValue = "true",
-    matchIfMissing = true)
-public class WarmupHealthIndicator implements HealthIndicator {
+    matchIfMissing = false)
+public class WarmupHealthIndicator implements ReactiveHealthIndicator {
 
   private final AtomicBoolean ready = new AtomicBoolean(false);
 
@@ -29,11 +30,11 @@ public class WarmupHealthIndicator implements HealthIndicator {
   }
 
   @Override
-  public Health health() {
+  public Mono<Health> health() {
     if (ready.get()) {
-      return Health.up().build();
+      return Mono.just(Health.up().build());
     }
-    return Health.down().withDetail("reason", "warmup in progress").build();
+    return Mono.just(Health.down().withDetail("reason", "warmup in progress").build());
   }
 
   public void setReady() {

--- a/src/main/java/jumper/service/TokenFetchService.java
+++ b/src/main/java/jumper/service/TokenFetchService.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import jumper.Constants;
 import jumper.model.TokenInfo;
@@ -52,6 +53,9 @@ public class TokenFetchService {
   private final TokenCacheService tokenCache;
   private final TokenGeneratorService tokenGeneratorService;
 
+  private final ConcurrentHashMap<String, Mono<TokenInfo>> inFlightTokenRequests =
+      new ConcurrentHashMap<>();
+
   public Mono<TokenInfo> getInternalMeshAccessToken(JumperConfig jc) {
     return getAccessTokenWithClientCredentials(
         jc.getInternalTokenEndpoint() + Constants.ISSUER_SUFFIX,
@@ -67,24 +71,28 @@ public class TokenFetchService {
         tokenCache.generateTokenCacheKey(tokenEndpoint, clientID, clientSecret, scope);
 
     // try to get valid token from tokenCache...
-    return tokenCache
-        .getToken(tokenKey)
-        .map(Mono::just)
-        .orElseGet(
-            () -> { // ...otherwise retrieve a new one
-              MultiValueMap<String, String> requestParameter = new LinkedMultiValueMap<>();
-              requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID, clientID);
-              requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_CLIENT_SECRET, clientSecret);
-              requestParameter.add(
-                  Constants.TOKEN_REQUEST_PARAMETER_GRANT_TYPE,
-                  AuthorizationGrantType.CLIENT_CREDENTIALS.getValue());
+    return Mono.defer(
+        () ->
+            tokenCache
+                .getToken(tokenKey)
+                .map(Mono::just)
+                .orElseGet(
+                    () -> { // ...otherwise retrieve a new one, coalescing concurrent requests
+                      MultiValueMap<String, String> requestParameter = new LinkedMultiValueMap<>();
+                      requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID, clientID);
+                      requestParameter.add(
+                          Constants.TOKEN_REQUEST_PARAMETER_CLIENT_SECRET, clientSecret);
+                      requestParameter.add(
+                          Constants.TOKEN_REQUEST_PARAMETER_GRANT_TYPE,
+                          AuthorizationGrantType.CLIENT_CREDENTIALS.getValue());
 
-              if (StringUtils.isNotBlank(scope)) {
-                requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_SCOPE, scope);
-              }
+                      if (StringUtils.isNotBlank(scope)) {
+                        requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_SCOPE, scope);
+                      }
 
-              return getAccessTokenQuery(tokenEndpoint, tokenKey, requestParameter, null);
-            });
+                      return getOrCreateInFlightRequest(
+                          tokenEndpoint, tokenKey, requestParameter, null);
+                    }));
   }
 
   public Mono<TokenInfo> getAccessTokenWithOauthCredentialsObject(
@@ -93,68 +101,77 @@ public class TokenFetchService {
     final String tokenKey = tokenCache.generateTokenCacheKey(tokenEndpoint, oauthCredentials);
 
     // try to get valid token from tokenCache...
-    return tokenCache
-        .getToken(tokenKey)
-        .map(Mono::just)
-        .orElseGet(
-            () -> { // ...otherwise retrieve a new one
-              MultiValueMap<String, String> requestParameter = new LinkedMultiValueMap<>();
-              String basicAuth = null;
+    return Mono.defer(
+        () ->
+            tokenCache
+                .getToken(tokenKey)
+                .map(Mono::just)
+                .orElseGet(
+                    () -> { // ...otherwise retrieve a new one, coalescing concurrent requests
+                      MultiValueMap<String, String> requestParameter = new LinkedMultiValueMap<>();
+                      String basicAuth = null;
 
-              if (StringUtils.isNotBlank(oauthCredentials.getClientKey())) {
-                requestParameter.add(
-                    Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID, oauthCredentials.getClientId());
-                requestParameter.add(
-                    Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION,
-                    createJwtTokenForExternalIdp(tokenEndpoint, oauthCredentials));
-                requestParameter.add(
-                    Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION_TYPE,
-                    Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION_TYPE_JWT);
-              }
+                      if (StringUtils.isNotBlank(oauthCredentials.getClientKey())) {
+                        requestParameter.add(
+                            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID,
+                            oauthCredentials.getClientId());
+                        requestParameter.add(
+                            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION,
+                            createJwtTokenForExternalIdp(tokenEndpoint, oauthCredentials));
+                        requestParameter.add(
+                            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION_TYPE,
+                            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION_TYPE_JWT);
+                      }
 
-              if (StringUtils.isNotBlank(oauthCredentials.getClientId())
-                  && StringUtils.isNotBlank(oauthCredentials.getClientSecret())) {
+                      if (StringUtils.isNotBlank(oauthCredentials.getClientId())
+                          && StringUtils.isNotBlank(oauthCredentials.getClientSecret())) {
 
-                if (StringUtils.isNotBlank(oauthCredentials.getTokenRequest())
-                    && StringUtils.equalsIgnoreCase(
-                        TOKEN_REQUEST_METHOD_POST, oauthCredentials.getTokenRequest())) {
-                  requestParameter.add(
-                      Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID, oauthCredentials.getClientId());
-                  requestParameter.add(
-                      Constants.TOKEN_REQUEST_PARAMETER_CLIENT_SECRET,
-                      oauthCredentials.getClientSecret());
-                } else {
-                  basicAuth =
-                      BasicAuthUtil.encodeBasicAuth(
-                          oauthCredentials.getClientId(), oauthCredentials.getClientSecret());
-                }
-              }
+                        if (StringUtils.isNotBlank(oauthCredentials.getTokenRequest())
+                            && StringUtils.equalsIgnoreCase(
+                                TOKEN_REQUEST_METHOD_POST, oauthCredentials.getTokenRequest())) {
+                          requestParameter.add(
+                              Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID,
+                              oauthCredentials.getClientId());
+                          requestParameter.add(
+                              Constants.TOKEN_REQUEST_PARAMETER_CLIENT_SECRET,
+                              oauthCredentials.getClientSecret());
+                        } else {
+                          basicAuth =
+                              BasicAuthUtil.encodeBasicAuth(
+                                  oauthCredentials.getClientId(),
+                                  oauthCredentials.getClientSecret());
+                        }
+                      }
 
-              if (StringUtils.isNotBlank(oauthCredentials.getUsername())
-                  && StringUtils.isNotBlank(oauthCredentials.getPassword())) {
+                      if (StringUtils.isNotBlank(oauthCredentials.getUsername())
+                          && StringUtils.isNotBlank(oauthCredentials.getPassword())) {
 
-                requestParameter.add(
-                    Constants.TOKEN_REQUEST_PARAMETER_USERNAME, oauthCredentials.getUsername());
-                requestParameter.add(
-                    Constants.TOKEN_REQUEST_PARAMETER_PASSWORD, oauthCredentials.getPassword());
-              }
+                        requestParameter.add(
+                            Constants.TOKEN_REQUEST_PARAMETER_USERNAME,
+                            oauthCredentials.getUsername());
+                        requestParameter.add(
+                            Constants.TOKEN_REQUEST_PARAMETER_PASSWORD,
+                            oauthCredentials.getPassword());
+                      }
 
-              if (StringUtils.isNotBlank(oauthCredentials.getRefreshToken())) {
-                requestParameter.add(
-                    Constants.TOKEN_REQUEST_PARAMETER_REFRESH_TOKEN,
-                    oauthCredentials.getRefreshToken());
-              }
+                      if (StringUtils.isNotBlank(oauthCredentials.getRefreshToken())) {
+                        requestParameter.add(
+                            Constants.TOKEN_REQUEST_PARAMETER_REFRESH_TOKEN,
+                            oauthCredentials.getRefreshToken());
+                      }
 
-              if (StringUtils.isNotEmpty(oauthCredentials.getScopes())) {
-                requestParameter.add(
-                    Constants.TOKEN_REQUEST_PARAMETER_SCOPE, oauthCredentials.getScopes());
-              }
+                      if (StringUtils.isNotEmpty(oauthCredentials.getScopes())) {
+                        requestParameter.add(
+                            Constants.TOKEN_REQUEST_PARAMETER_SCOPE, oauthCredentials.getScopes());
+                      }
 
-              requestParameter.add(
-                  Constants.TOKEN_REQUEST_PARAMETER_GRANT_TYPE, oauthCredentials.getGrantType());
+                      requestParameter.add(
+                          Constants.TOKEN_REQUEST_PARAMETER_GRANT_TYPE,
+                          oauthCredentials.getGrantType());
 
-              return getAccessTokenQuery(tokenEndpoint, tokenKey, requestParameter, basicAuth);
-            });
+                      return getOrCreateInFlightRequest(
+                          tokenEndpoint, tokenKey, requestParameter, basicAuth);
+                    }));
   }
 
   private String createJwtTokenForExternalIdp(
@@ -178,6 +195,21 @@ public class TokenFetchService {
         new Date(System.currentTimeMillis() + 60 * 1000),
         new Date(System.currentTimeMillis()),
         oauthCredentials.getClientKey());
+  }
+
+  private Mono<TokenInfo> getOrCreateInFlightRequest(
+      String tokenEndpoint,
+      String tokenKey,
+      MultiValueMap<String, String> formData,
+      String basicAuthHeader) {
+    return inFlightTokenRequests.computeIfAbsent(
+        tokenKey,
+        k -> {
+          log.debug("Creating new token request for key: {}", tokenKey);
+          return getAccessTokenQuery(tokenEndpoint, tokenKey, formData, basicAuthHeader)
+              .doFinally(signal -> inFlightTokenRequests.remove(tokenKey))
+              .cache();
+        });
   }
 
   private Mono<TokenInfo> getAccessTokenQuery(
@@ -259,7 +291,8 @@ public class TokenFetchService {
                     throwable.getClass().getSimpleName(),
                     throwable.getMessage()))
         .retryWhen(
-            Retry.max(2)
+            Retry.backoff(2, Duration.ofMillis(200))
+                .maxBackoff(Duration.ofSeconds(2))
                 .filter(
                     throwable ->
                         throwable instanceof ConnectTimeoutException

--- a/src/main/java/jumper/service/WarmupService.java
+++ b/src/main/java/jumper/service/WarmupService.java
@@ -34,7 +34,7 @@ import reactor.core.publisher.Mono;
     prefix = "jumper.warmup",
     name = "enabled",
     havingValue = "true",
-    matchIfMissing = true)
+    matchIfMissing = false)
 public class WarmupService {
 
   private final WarmupProperties warmupProperties;
@@ -58,7 +58,7 @@ public class WarmupService {
     }
   }
 
-  @Value("${server.port:8080}")
+  @Value("${server.port}")
   private int serverPort;
 
   @EventListener(ApplicationReadyEvent.class)

--- a/src/main/java/jumper/service/WarmupService.java
+++ b/src/main/java/jumper/service/WarmupService.java
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import jumper.Constants;
+import jumper.config.WarmupProperties;
+import jumper.health.WarmupHealthIndicator;
+import jumper.model.config.JumperConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(
+    prefix = "jumper.warmup",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WarmupService {
+
+  private final WarmupProperties warmupProperties;
+  private final WarmupHealthIndicator warmupHealthIndicator;
+  private final KeyPair warmupKeyPair;
+
+  public WarmupService(
+      WarmupProperties warmupProperties, WarmupHealthIndicator warmupHealthIndicator) {
+    this.warmupProperties = warmupProperties;
+    this.warmupHealthIndicator = warmupHealthIndicator;
+    this.warmupKeyPair = generateEcKeyPair();
+  }
+
+  private static KeyPair generateEcKeyPair() {
+    try {
+      KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+      keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+      return keyGen.generateKeyPair();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to generate EC keypair for warmup", e);
+    }
+  }
+
+  @Value("${server.port:8080}")
+  private int serverPort;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void onApplicationReady() {
+    List<String> urls = warmupProperties.getUrls();
+    if (urls == null || urls.isEmpty()) {
+      log.info("Warmup: no URLs configured, skipping");
+      return;
+    }
+
+    Duration timeout = warmupProperties.getTimeout();
+    log.info("Warmup: starting for {} URL(s) with {}s timeout", urls.size(), timeout.toSeconds());
+
+    long start = System.currentTimeMillis();
+
+    Flux.fromIterable(urls)
+        .flatMap(this::warmupUrl)
+        .timeout(timeout)
+        .onErrorResume(
+            throwable -> {
+              log.warn("Warmup: aborted due to timeout or error: {}", throwable.getMessage());
+              return Mono.empty();
+            })
+        .doFinally(
+            signal -> {
+              long elapsed = System.currentTimeMillis() - start;
+              log.info("Warmup: completed in {}ms (signal={})", elapsed, signal);
+              warmupHealthIndicator.setReady();
+            })
+        .subscribe();
+  }
+
+  private Mono<Void> warmupUrl(String url) {
+    log.info("Warmup: warming up {}", url);
+    long start = System.currentTimeMillis();
+
+    try {
+      String consumerToken = buildSyntheticConsumerToken();
+      String jumperConfigBase64 = buildWarmupJumperConfig(url);
+
+      WebClient warmupClient =
+          WebClient.builder().baseUrl("http://localhost:" + serverPort).build();
+
+      return warmupClient
+          .get()
+          .uri(Constants.PROXY_ROOT_PATH_PREFIX + "/warmup")
+          .header(Constants.HEADER_JUMPER_CONFIG, jumperConfigBase64)
+          .header(Constants.HEADER_AUTHORIZATION, consumerToken)
+          .header(Constants.HEADER_REMOTE_API_URL, url)
+          .header(Constants.HEADER_API_BASE_PATH, "/")
+          .header(Constants.HEADER_REALM, Constants.DEFAULT_REALM)
+          .header(Constants.HEADER_ENVIRONMENT, "warmup")
+          .accept(MediaType.APPLICATION_JSON)
+          .exchangeToMono(response -> response.releaseBody())
+          .doOnSuccess(
+              v ->
+                  log.info("Warmup: {} completed in {}ms", url, System.currentTimeMillis() - start))
+          .doOnError(
+              throwable ->
+                  log.warn(
+                      "Warmup: {} failed after {}ms: {}",
+                      url,
+                      System.currentTimeMillis() - start,
+                      throwable.getMessage()))
+          .onErrorResume(throwable -> Mono.empty());
+
+    } catch (Exception e) {
+      log.error("Warmup: failed to build warmup request for {}: {}", url, e.getMessage());
+      return Mono.empty();
+    }
+  }
+
+  String buildWarmupJumperConfig(String url) {
+    JumperConfig jc = new JumperConfig();
+    jc.setRemoteApiUrl(url);
+    jc.setApiBasePath("/");
+    jc.setRealmName(Constants.DEFAULT_REALM);
+    jc.setEnvName("warmup");
+    // No internalTokenEndpoint, no externalTokenEndpoint → triggers LMS token path
+    return JumperConfig.toJsonBase64(jc);
+  }
+
+  private String buildSyntheticConsumerToken() {
+    HashMap<String, Object> claims = new HashMap<>();
+    claims.put(Constants.TOKEN_CLAIM_CLIENT_ID, "warmup");
+    claims.put(Constants.TOKEN_CLAIM_ORIGIN_STARGATE, "warmup");
+    claims.put(Constants.TOKEN_CLAIM_ORIGIN_ZONE, "warmup");
+    claims.put(Constants.TOKEN_CLAIM_SUB, "warmup");
+    claims.put(Constants.TOKEN_CLAIM_TYP, "Bearer");
+
+    String token =
+        Jwts.builder()
+            .setClaims(claims)
+            .setIssuer("warmup")
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(System.currentTimeMillis() + 300_000))
+            .signWith(warmupKeyPair.getPrivate(), SignatureAlgorithm.ES256)
+            .compact();
+
+    return Constants.BEARER + " " + token;
+  }
+}

--- a/src/main/java/jumper/service/WarmupService.java
+++ b/src/main/java/jumper/service/WarmupService.java
@@ -83,9 +83,11 @@ public class WarmupService {
     AtomicInteger successCount = new AtomicInteger();
     AtomicInteger failureCount = new AtomicInteger();
 
+    WebClient warmupClient = WebClient.builder().baseUrl("http://localhost:" + serverPort).build();
+
     Flux.fromIterable(urls)
         .repeat(iterations - 1)
-        .concatMap(url -> warmupUrl(url, successCount, failureCount))
+        .concatMap(url -> warmupUrl(warmupClient, url, successCount, failureCount))
         .timeout(timeout)
         .onErrorResume(
             throwable -> {
@@ -107,16 +109,14 @@ public class WarmupService {
         .subscribe();
   }
 
-  private Mono<Void> warmupUrl(String url, AtomicInteger successCount, AtomicInteger failureCount) {
+  private Mono<Void> warmupUrl(
+      WebClient warmupClient, String url, AtomicInteger successCount, AtomicInteger failureCount) {
     log.debug("Warmup: warming up {}", url);
     long start = System.currentTimeMillis();
 
     try {
       String consumerToken = buildSyntheticConsumerToken();
       String jumperConfigBase64 = buildWarmupJumperConfig(url);
-
-      WebClient warmupClient =
-          WebClient.builder().baseUrl("http://localhost:" + serverPort).build();
 
       return warmupClient
           .get()

--- a/src/main/java/jumper/service/WarmupService.java
+++ b/src/main/java/jumper/service/WarmupService.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import jumper.Constants;
 import jumper.config.WarmupProperties;
 import jumper.health.WarmupHealthIndicator;
@@ -70,12 +71,21 @@ public class WarmupService {
     }
 
     Duration timeout = warmupProperties.getTimeout();
-    log.info("Warmup: starting for {} URL(s) with {}s timeout", urls.size(), timeout.toSeconds());
+    int iterations = Math.max(1, warmupProperties.getIterations());
+    log.info(
+        "Warmup: starting for {} URL(s) x {} iterations with {}s timeout",
+        urls.size(),
+        iterations,
+        timeout.toSeconds());
 
     long start = System.currentTimeMillis();
+    int totalRequests = urls.size() * iterations;
+    AtomicInteger successCount = new AtomicInteger();
+    AtomicInteger failureCount = new AtomicInteger();
 
     Flux.fromIterable(urls)
-        .flatMap(this::warmupUrl)
+        .repeat(iterations - 1)
+        .concatMap(url -> warmupUrl(url, successCount, failureCount))
         .timeout(timeout)
         .onErrorResume(
             throwable -> {
@@ -85,14 +95,20 @@ public class WarmupService {
         .doFinally(
             signal -> {
               long elapsed = System.currentTimeMillis() - start;
-              log.info("Warmup: completed in {}ms (signal={})", elapsed, signal);
+              log.info(
+                  "Warmup: completed in {}ms — {}/{} succeeded, {} failed (signal={})",
+                  elapsed,
+                  successCount.get(),
+                  totalRequests,
+                  failureCount.get(),
+                  signal);
               warmupHealthIndicator.setReady();
             })
         .subscribe();
   }
 
-  private Mono<Void> warmupUrl(String url) {
-    log.info("Warmup: warming up {}", url);
+  private Mono<Void> warmupUrl(String url, AtomicInteger successCount, AtomicInteger failureCount) {
+    log.debug("Warmup: warming up {}", url);
     long start = System.currentTimeMillis();
 
     try {
@@ -114,18 +130,23 @@ public class WarmupService {
           .accept(MediaType.APPLICATION_JSON)
           .exchangeToMono(response -> response.releaseBody())
           .doOnSuccess(
-              v ->
-                  log.info("Warmup: {} completed in {}ms", url, System.currentTimeMillis() - start))
+              v -> {
+                successCount.incrementAndGet();
+                log.debug("Warmup: {} completed in {}ms", url, System.currentTimeMillis() - start);
+              })
           .doOnError(
-              throwable ->
-                  log.warn(
-                      "Warmup: {} failed after {}ms: {}",
-                      url,
-                      System.currentTimeMillis() - start,
-                      throwable.getMessage()))
+              throwable -> {
+                failureCount.incrementAndGet();
+                log.warn(
+                    "Warmup: {} failed after {}ms: {}",
+                    url,
+                    System.currentTimeMillis() - start,
+                    throwable.getMessage());
+              })
           .onErrorResume(throwable -> Mono.empty());
 
     } catch (Exception e) {
+      failureCount.incrementAndGet();
       log.error("Warmup: failed to build warmup request for {}: {}", url, e.getMessage());
       return Mono.empty();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,9 @@ management:
     health:
       probes:
         enabled: true #healthcheck probes, liveness and readiness
+      group:
+        readiness:
+          include: readinessState, warmup
   endpoints:
     web:
       exposure.include: prometheus, health
@@ -181,6 +184,10 @@ jumper:
     ttlOffset: 10
     maxSize: 10000
     expireAfterWriteMinutes: 30
+  warmup:
+    enabled: true
+    timeout: 15s
+    urls: 
   horizon:
     publishEventUrl: ${PUBLISH_EVENT_URL:http://producer.stage:8080/v1/events}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -187,6 +187,7 @@ jumper:
   warmup:
     enabled: false
     timeout: 15s
+    iterations: 1
     urls: 
   horizon:
     publishEventUrl: ${PUBLISH_EVENT_URL:http://producer.stage:8080/v1/events}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ management:
         enabled: true #healthcheck probes, liveness and readiness
       group:
         readiness:
-          include: readinessState, warmup
+          include: readinessState
   endpoints:
     web:
       exposure.include: prometheus, health
@@ -185,7 +185,7 @@ jumper:
     maxSize: 10000
     expireAfterWriteMinutes: 30
   warmup:
-    enabled: true
+    enabled: false
     timeout: 15s
     urls: 
   horizon:

--- a/src/test/java/jumper/service/TokenFetchServiceTest.java
+++ b/src/test/java/jumper/service/TokenFetchServiceTest.java
@@ -195,10 +195,9 @@ class TokenFetchServiceTest {
   void failedIdpCall_cleansUpInFlightEntry_allowsRetry() {
     when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
 
-    // Wire up a failing WebClient
-    WebClient failingWebClient = mockFailingWebClient();
-    tokenFetchService =
-        new TokenFetchService(failingWebClient, tokenCacheService, tokenGeneratorService);
+    // Wire up a WebClient that fails first, then succeeds on the next call
+    WebClient webClient = mockFailThenSucceedWebClient(createTokenInfo(3600));
+    tokenFetchService = new TokenFetchService(webClient, tokenCacheService, tokenGeneratorService);
 
     // First request fails
     StepVerifier.create(
@@ -207,11 +206,7 @@ class TokenFetchServiceTest {
         .expectError()
         .verify(Duration.ofSeconds(5));
 
-    // Now swap in a working WebClient and verify the in-flight map was cleaned up
-    WebClient workingWebClient = mockWebClient(createTokenInfo(3600), Duration.ZERO);
-    tokenFetchService =
-        new TokenFetchService(workingWebClient, tokenCacheService, tokenGeneratorService);
-
+    // Second request on the SAME instance succeeds — proves the in-flight entry was cleaned up
     StepVerifier.create(
             tokenFetchService.getAccessTokenWithClientCredentials(
                 TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
@@ -257,12 +252,14 @@ class TokenFetchServiceTest {
   }
 
   @SuppressWarnings("unchecked")
-  private WebClient mockFailingWebClient() {
+  private WebClient mockFailThenSucceedWebClient(TokenInfo responseToken) {
     WebClient webClient = mock(WebClient.class);
     WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
     WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
     WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
     WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+    AtomicInteger callCount = new AtomicInteger(0);
 
     when(webClient.post()).thenReturn(requestBodyUriSpec);
     when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
@@ -271,7 +268,14 @@ class TokenFetchServiceTest {
     when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
     when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
     when(responseSpec.bodyToMono(TokenInfo.class))
-        .thenReturn(Mono.error(new RuntimeException("IDP unavailable")));
+        .thenReturn(
+            Mono.defer(
+                () -> {
+                  if (callCount.getAndIncrement() == 0) {
+                    return Mono.error(new RuntimeException("IDP unavailable"));
+                  }
+                  return Mono.just(responseToken);
+                }));
 
     return webClient;
   }

--- a/src/test/java/jumper/service/TokenFetchServiceTest.java
+++ b/src/test/java/jumper/service/TokenFetchServiceTest.java
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import jumper.model.TokenInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TokenFetchServiceTest {
+
+  private static final String TOKEN_ENDPOINT = "https://idp.example.com/token";
+  private static final String CLIENT_ID = "test-client";
+  private static final String CLIENT_SECRET = "test-secret";
+  private static final String TOKEN_CACHE_KEY = "test-cache-key";
+
+  private TokenCacheService tokenCacheService;
+  private TokenGeneratorService tokenGeneratorService;
+  private TokenFetchService tokenFetchService;
+
+  private AtomicInteger idpCallCount;
+
+  @BeforeEach
+  void setUp() {
+    tokenCacheService = mock(TokenCacheService.class);
+    tokenGeneratorService = mock(TokenGeneratorService.class);
+    idpCallCount = new AtomicInteger(0);
+
+    when(tokenCacheService.generateTokenCacheKey(anyString(), anyString(), anyString(), any()))
+        .thenReturn(TOKEN_CACHE_KEY);
+
+    WebClient webClient = mockWebClient(createTokenInfo(3600), Duration.ZERO);
+
+    tokenFetchService = new TokenFetchService(webClient, tokenCacheService, tokenGeneratorService);
+  }
+
+  @Test
+  void singleRequest_cacheMiss_fetchesTokenFromIdp() {
+    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .assertNext(
+            token -> {
+              assertThat(token.getAccessToken()).isEqualTo("mocked-access-token");
+              assertThat(idpCallCount.get()).isEqualTo(1);
+            })
+        .verifyComplete();
+
+    verify(tokenCacheService).saveToken(eq(TOKEN_CACHE_KEY), any(TokenInfo.class));
+  }
+
+  @Test
+  void singleRequest_cacheHit_doesNotCallIdp() {
+    TokenInfo cachedToken = createTokenInfo(3600);
+    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.of(cachedToken));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .assertNext(
+            token -> {
+              assertThat(token.getAccessToken()).isEqualTo("mocked-access-token");
+              assertThat(idpCallCount.get()).isEqualTo(0);
+            })
+        .verifyComplete();
+
+    verify(tokenCacheService, never()).saveToken(anyString(), any(TokenInfo.class));
+  }
+
+  @Test
+  void concurrentRequests_cacheMiss_onlySingleIdpCall() {
+    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
+
+    // Recreate with a slow IDP response to widen the race window
+    WebClient slowWebClient = mockWebClient(createTokenInfo(3600), Duration.ofMillis(200));
+    tokenFetchService =
+        new TokenFetchService(slowWebClient, tokenCacheService, tokenGeneratorService);
+
+    int concurrentRequests = 50;
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(concurrentRequests);
+    AtomicInteger successCount = new AtomicInteger(0);
+
+    for (int i = 0; i < concurrentRequests; i++) {
+      new Thread(
+              () -> {
+                try {
+                  startLatch.await();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  return;
+                }
+                tokenFetchService
+                    .getAccessTokenWithClientCredentials(
+                        TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+                    .doOnNext(token -> successCount.incrementAndGet())
+                    .block(Duration.ofSeconds(5));
+                doneLatch.countDown();
+              })
+          .start();
+    }
+
+    // Release all threads simultaneously
+    startLatch.countDown();
+
+    try {
+      doneLatch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    assertThat(successCount.get()).isEqualTo(concurrentRequests);
+    assertThat(idpCallCount.get())
+        .as("Expected exactly 1 IDP call for %d concurrent requests", concurrentRequests)
+        .isEqualTo(1);
+  }
+
+  @Test
+  void concurrentRequests_differentKeys_makesSeparateIdpCalls() {
+    String tokenKey1 = "key-zone-A";
+    String tokenKey2 = "key-zone-B";
+
+    when(tokenCacheService.generateTokenCacheKey(
+            eq("https://zone-a.example.com/token"), anyString(), anyString(), any()))
+        .thenReturn(tokenKey1);
+    when(tokenCacheService.generateTokenCacheKey(
+            eq("https://zone-b.example.com/token"), anyString(), anyString(), any()))
+        .thenReturn(tokenKey2);
+    when(tokenCacheService.getToken(anyString())).thenReturn(Optional.empty());
+
+    WebClient slowWebClient = mockWebClient(createTokenInfo(3600), Duration.ofMillis(100));
+    tokenFetchService =
+        new TokenFetchService(slowWebClient, tokenCacheService, tokenGeneratorService);
+
+    Mono<TokenInfo> zoneA =
+        tokenFetchService.getAccessTokenWithClientCredentials(
+            "https://zone-a.example.com/token", CLIENT_ID, CLIENT_SECRET, null);
+    Mono<TokenInfo> zoneB =
+        tokenFetchService.getAccessTokenWithClientCredentials(
+            "https://zone-b.example.com/token", CLIENT_ID, CLIENT_SECRET, null);
+
+    StepVerifier.create(Mono.zip(zoneA, zoneB))
+        .assertNext(
+            tuple -> {
+              assertThat(tuple.getT1().getAccessToken()).isEqualTo("mocked-access-token");
+              assertThat(tuple.getT2().getAccessToken()).isEqualTo("mocked-access-token");
+              assertThat(idpCallCount.get())
+                  .as("Expected 2 separate IDP calls for 2 different zones")
+                  .isEqualTo(2);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void afterCompletedRequest_nextRequestMakesNewIdpCall() {
+    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
+
+    // First request
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectNextCount(1)
+        .verifyComplete();
+
+    assertThat(idpCallCount.get()).isEqualTo(1);
+
+    // Second request (cache still empty — simulates eviction)
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectNextCount(1)
+        .verifyComplete();
+
+    assertThat(idpCallCount.get())
+        .as("After the first in-flight completes, a new request should trigger a fresh IDP call")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void failedIdpCall_cleansUpInFlightEntry_allowsRetry() {
+    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
+
+    // Wire up a failing WebClient
+    WebClient failingWebClient = mockFailingWebClient();
+    tokenFetchService =
+        new TokenFetchService(failingWebClient, tokenCacheService, tokenGeneratorService);
+
+    // First request fails
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectError()
+        .verify(Duration.ofSeconds(5));
+
+    // Now swap in a working WebClient and verify the in-flight map was cleaned up
+    WebClient workingWebClient = mockWebClient(createTokenInfo(3600), Duration.ZERO);
+    tokenFetchService =
+        new TokenFetchService(workingWebClient, tokenCacheService, tokenGeneratorService);
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .assertNext(token -> assertThat(token.getAccessToken()).isEqualTo("mocked-access-token"))
+        .verifyComplete();
+  }
+
+  // --- helpers ---
+
+  private TokenInfo createTokenInfo(int expiresInSeconds) {
+    TokenInfo tokenInfo = new TokenInfo();
+    tokenInfo.setAccessToken("mocked-access-token");
+    tokenInfo.setExpiresIn(expiresInSeconds);
+    tokenInfo.setTokenType("Bearer");
+    return tokenInfo;
+  }
+
+  @SuppressWarnings("unchecked")
+  private WebClient mockWebClient(TokenInfo responseToken, Duration delay) {
+    WebClient webClient = mock(WebClient.class);
+    WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+    WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+    WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+    WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+    when(webClient.post()).thenReturn(requestBodyUriSpec);
+    when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+    when(requestBodySpec.headers(any())).thenReturn(requestBodySpec);
+    when(requestBodySpec.body(any())).thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+    when(responseSpec.bodyToMono(TokenInfo.class))
+        .thenReturn(
+            Mono.defer(
+                () -> {
+                  idpCallCount.incrementAndGet();
+                  return delay.isZero()
+                      ? Mono.just(responseToken)
+                      : Mono.just(responseToken).delayElement(delay);
+                }));
+
+    return webClient;
+  }
+
+  @SuppressWarnings("unchecked")
+  private WebClient mockFailingWebClient() {
+    WebClient webClient = mock(WebClient.class);
+    WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+    WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+    WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+    WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+    when(webClient.post()).thenReturn(requestBodyUriSpec);
+    when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+    when(requestBodySpec.headers(any())).thenReturn(requestBodySpec);
+    when(requestBodySpec.body(any())).thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+    when(responseSpec.bodyToMono(TokenInfo.class))
+        .thenReturn(Mono.error(new RuntimeException("IDP unavailable")));
+
+    return webClient;
+  }
+}

--- a/src/test/java/jumper/service/WarmupIntegrationTest.java
+++ b/src/test/java/jumper/service/WarmupIntegrationTest.java
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwt;
+import jumper.Constants;
+import jumper.model.config.JumperConfig;
+import jumper.util.OauthTokenUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "jumper.warmup.enabled=false",
+      "management.endpoint.health.group.readiness.include=readinessState"
+    })
+@ActiveProfiles("test")
+@AutoConfigureObservability
+@AutoConfigureWebTestClient(timeout = "PT10S")
+class WarmupIntegrationTest {
+
+  private static final int MOCK_UPSTREAM_PORT = 1090;
+
+  static ClientAndServer mockUpstream;
+  static MockServerClient mockClient;
+
+  @Autowired WebTestClient webTestClient;
+
+  @BeforeAll
+  static void startMockUpstream() {
+    mockUpstream = startClientAndServer(MOCK_UPSTREAM_PORT);
+    mockClient = new MockServerClient("localhost", MOCK_UPSTREAM_PORT);
+    mockClient.when(request()).respond(response().withStatusCode(200));
+  }
+
+  @AfterAll
+  static void stopMockUpstream() {
+    if (mockUpstream != null) {
+      mockUpstream.stop();
+    }
+  }
+
+  @Test
+  void warmupRequestReachesUpstreamWithLmsToken() {
+    String remoteApiUrl = "http://localhost:" + MOCK_UPSTREAM_PORT;
+
+    // Build warmup jumper_config pointing at the mock upstream
+    JumperConfig jc = new JumperConfig();
+    jc.setRemoteApiUrl(remoteApiUrl);
+    jc.setApiBasePath("/");
+    jc.setRealmName(Constants.DEFAULT_REALM);
+    jc.setEnvName("warmup");
+    String jumperConfigBase64 = JumperConfig.toJsonBase64(jc);
+
+    // Build a synthetic consumer token (same as WarmupService does)
+    String consumerToken = jumper.util.TokenUtil.getConsumerAccessToken();
+
+    // Send the warmup-style request through Jumper's filter chain
+    // Includes remote_api_url legacy header required by fillWithLegacyHeaders
+    webTestClient
+        .get()
+        .uri(Constants.PROXY_ROOT_PATH_PREFIX + "/warmup")
+        .header(Constants.HEADER_JUMPER_CONFIG, jumperConfigBase64)
+        .header(Constants.HEADER_AUTHORIZATION, "Bearer " + consumerToken)
+        .header(Constants.HEADER_REMOTE_API_URL, remoteApiUrl)
+        .header(Constants.HEADER_API_BASE_PATH, "/")
+        .header(Constants.HEADER_REALM, Constants.DEFAULT_REALM)
+        .header(Constants.HEADER_ENVIRONMENT, "warmup")
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    // Verify the mock upstream received the request
+    HttpRequest[] recordedRequests = mockClient.retrieveRecordedRequests(request());
+    assertThat(recordedRequests)
+        .as("Mock upstream should have received the warmup request")
+        .isNotEmpty();
+
+    // Verify the upstream received a Bearer authorization header (LMS token, not the consumer
+    // token)
+    String authHeader = recordedRequests[0].getFirstHeader("Authorization");
+    assertThat(authHeader).startsWith("Bearer ");
+
+    // Parse the LMS token and verify it has expected claims
+    Jwt<?, Claims> claimsFromToken =
+        OauthTokenUtil.getAllClaimsFromToken(OauthTokenUtil.getTokenWithoutSignature(authHeader));
+
+    assertThat(claimsFromToken.getBody().get("env", String.class)).isEqualTo("warmup");
+    assertThat(claimsFromToken.getBody().get("typ", String.class)).isEqualTo("Bearer");
+    assertThat(claimsFromToken.getBody().getIssuer()).contains("/default");
+  }
+}

--- a/src/test/java/jumper/service/WarmupIntegrationTest.java
+++ b/src/test/java/jumper/service/WarmupIntegrationTest.java
@@ -29,10 +29,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-      "jumper.warmup.enabled=false",
-      "management.endpoint.health.group.readiness.include=readinessState"
-    })
+    properties = {"jumper.warmup.enabled=false"})
 @ActiveProfiles("test")
 @AutoConfigureObservability
 @AutoConfigureWebTestClient(timeout = "PT10S")

--- a/src/test/java/jumper/service/WarmupServiceTest.java
+++ b/src/test/java/jumper/service/WarmupServiceTest.java
@@ -62,7 +62,7 @@ class WarmupServiceTest {
 
     WarmupHealthIndicator healthIndicator = new WarmupHealthIndicator(properties);
     assertThat(healthIndicator.isReady()).isFalse();
-    assertThat(healthIndicator.health().getStatus().getCode()).isEqualTo("DOWN");
+    assertThat(healthIndicator.health().block().getStatus().getCode()).isEqualTo("DOWN");
   }
 
   @Test
@@ -78,7 +78,7 @@ class WarmupServiceTest {
     healthIndicator.setReady();
 
     assertThat(healthIndicator.isReady()).isTrue();
-    assertThat(healthIndicator.health().getStatus().getCode()).isEqualTo("UP");
+    assertThat(healthIndicator.health().block().getStatus().getCode()).isEqualTo("UP");
   }
 
   @Test
@@ -90,7 +90,7 @@ class WarmupServiceTest {
 
     WarmupHealthIndicator healthIndicator = new WarmupHealthIndicator(properties);
     assertThat(healthIndicator.isReady()).isTrue();
-    assertThat(healthIndicator.health().getStatus().getCode()).isEqualTo("UP");
+    assertThat(healthIndicator.health().block().getStatus().getCode()).isEqualTo("UP");
   }
 
   @Test

--- a/src/test/java/jumper/service/WarmupServiceTest.java
+++ b/src/test/java/jumper/service/WarmupServiceTest.java
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.List;
+import jumper.config.WarmupProperties;
+import jumper.health.WarmupHealthIndicator;
+import org.junit.jupiter.api.Test;
+
+class WarmupServiceTest {
+
+  @Test
+  void onApplicationReady_noUrls_skipsWarmupAndKeepsReadyState() {
+    WarmupProperties properties = new WarmupProperties();
+    properties.setEnabled(true);
+    properties.setTimeout(Duration.ofSeconds(15));
+    properties.setUrls(List.of());
+
+    WarmupHealthIndicator healthIndicator = new WarmupHealthIndicator(properties);
+    // With empty domains, the health indicator should already be ready
+    assertThat(healthIndicator.isReady()).isTrue();
+
+    WarmupService service = new WarmupService(properties, healthIndicator);
+    // Should not throw, just log and return
+    service.onApplicationReady();
+
+    assertThat(healthIndicator.isReady()).isTrue();
+  }
+
+  @Test
+  void onApplicationReady_withUrls_setsReadyAfterTimeout() throws InterruptedException {
+    WarmupProperties properties = new WarmupProperties();
+    properties.setEnabled(true);
+    properties.setTimeout(Duration.ofSeconds(2));
+    // Use a non-routable address to trigger connection timeout quickly
+    properties.setUrls(List.of("https://192.0.2.1"));
+
+    WarmupHealthIndicator healthIndicator = mock(WarmupHealthIndicator.class);
+
+    WarmupService service = new WarmupService(properties, healthIndicator);
+    service.onApplicationReady();
+
+    // Wait for async warmup to complete (timeout + buffer)
+    Thread.sleep(3000);
+
+    // The health indicator should have been set to ready after warmup completes/times out
+    verify(healthIndicator, atLeastOnce()).setReady();
+  }
+
+  @Test
+  void healthIndicator_startsDown_withUrls() {
+    WarmupProperties properties = new WarmupProperties();
+    properties.setEnabled(true);
+    properties.setTimeout(Duration.ofSeconds(15));
+    properties.setUrls(List.of("https://example.com"));
+
+    WarmupHealthIndicator healthIndicator = new WarmupHealthIndicator(properties);
+    assertThat(healthIndicator.isReady()).isFalse();
+    assertThat(healthIndicator.health().getStatus().getCode()).isEqualTo("DOWN");
+  }
+
+  @Test
+  void healthIndicator_flipsUp_afterSetReady() {
+    WarmupProperties properties = new WarmupProperties();
+    properties.setEnabled(true);
+    properties.setTimeout(Duration.ofSeconds(15));
+    properties.setUrls(List.of("https://example.com"));
+
+    WarmupHealthIndicator healthIndicator = new WarmupHealthIndicator(properties);
+    assertThat(healthIndicator.isReady()).isFalse();
+
+    healthIndicator.setReady();
+
+    assertThat(healthIndicator.isReady()).isTrue();
+    assertThat(healthIndicator.health().getStatus().getCode()).isEqualTo("UP");
+  }
+
+  @Test
+  void healthIndicator_immediatelyReady_withEmptyUrls() {
+    WarmupProperties properties = new WarmupProperties();
+    properties.setEnabled(true);
+    properties.setTimeout(Duration.ofSeconds(15));
+    properties.setUrls(List.of());
+
+    WarmupHealthIndicator healthIndicator = new WarmupHealthIndicator(properties);
+    assertThat(healthIndicator.isReady()).isTrue();
+    assertThat(healthIndicator.health().getStatus().getCode()).isEqualTo("UP");
+  }
+
+  @Test
+  void healthIndicator_immediatelyReady_withNullUrls() {
+    WarmupProperties properties = new WarmupProperties();
+    properties.setEnabled(true);
+    properties.setTimeout(Duration.ofSeconds(15));
+    properties.setUrls(null);
+
+    WarmupHealthIndicator healthIndicator = new WarmupHealthIndicator(properties);
+    assertThat(healthIndicator.isReady()).isTrue();
+  }
+}


### PR DESCRIPTION
Introduces a startup warmup mechanism for Jumper that exercises the request filter chain (including LMS token generation) before the pod accepts traffic, significantly reducing cold start latency. Additionally fixes a thundering herd problem in the token fetch layer.

**Warmup Component (feat)**


- WarmupProperties — new @ConfigurationProperties block under jumper.warmup.* with settings for enabled (default: false), target domains, and iterations (default: 1)
- WarmupService — triggered on ApplicationReadyEvent:
  - Iterates configured domains in parallel
  - Sends synthetic GET /proxy/warmup requests to localhost with a crafted jumper_config
  - Generates a minimal self-signed consumer JWT for the Authorization header
  - Supports configurable iteration count per URL (jumper.warmup.iterations) for deeper warm-up
  - 15 s hard timeout; per-domain errors are caught and logged
  - Flips readiness to UP on completion
- WarmupHealthIndicator — bound to the Kubernetes readiness probe; reports DOWN until the warmup cycle completes, preventing premature traffic routing
- Readiness health group updated to include the warmup indicator
- Unit tests for WarmupService and WarmupHealthIndicator

**Token Fetch Singleflight Fix (fix)**

During startup or cache expiry, concurrent requests for the same token (e.g. mesh token per zone) each independently called the IDP, causing a thundering herd of duplicate requests and mass client errors (401/429).

- TokenFetchService — added ConcurrentHashMap-based singleflight so only one HTTP token request is in-flight per tokenKey at a time; all concurrent subscribers share the same Mono result via .cache()
- Wrapped cache lookups in Mono.defer() for proper per-subscription evaluation
- Changed Retry.max(2) → Retry.backoff(2, 200ms) to avoid hammering an overloaded IDP with immediate retries
- 6 unit tests covering coalescing, cache hit/miss, multi-key isolation, cleanup after completion/failure