### PR TITLE
fix(warmup): improve log messages and success/skip/failure counting

### DIFF
--- a/src/main/java/jumper/service/WarmupService.java
+++ b/src/main/java/jumper/service/WarmupService.java
@@ -91,17 +91,17 @@ public class WarmupService {
         .timeout(timeout)
         .onErrorResume(
             throwable -> {
-              log.warn("Warmup: aborted due to timeout or error: {}", throwable.getMessage());
+              log.info("Warmup: concluded end due to timeout or error: {}", throwable.getMessage());
               return Mono.empty();
             })
         .doFinally(
             signal -> {
               long elapsed = System.currentTimeMillis() - start;
               log.info(
-                  "Warmup: completed in {}ms — {}/{} succeeded, {} failed (signal={})",
+                  "Warmup: completed in {}ms — {} succeeded, {} skipped, {} failed (signal={})",
                   elapsed,
                   successCount.get(),
-                  totalRequests,
+                  totalRequests - successCount.get() - failureCount.get(),
                   failureCount.get(),
                   signal);
               warmupHealthIndicator.setReady();


### PR DESCRIPTION
- Change 'aborted' to 'concluded end' in timeout/error log message
- Update completion log to show succeeded/skipped/failed instead of succeeded/total/failed
- Calculate skipped count as totalRequests - successCount - failureCount