### PR TITLE
ci: split image build and push for secure handling of PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
 
 permissions:
   contents: read
@@ -89,6 +87,15 @@ jobs:
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Save release tag
+        if: inputs.tag != ''
+        run: echo "${{ inputs.tag }}" > release-tag.txt
+      - name: Upload release tag
+        if: inputs.tag != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: release-tag
+          path: release-tag.txt
 
   test-maven:
     name: Run unit tests
@@ -119,85 +126,3 @@ jobs:
           name: test-results
           path: |
             **/target/surefire-reports/
-
-  build-image:
-    name: Build container image
-    runs-on: ubuntu-latest
-    needs: [build-maven, test-maven]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-      - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: "maven"
-      - name: Cache maven target dir
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
-        with:
-          path: target
-          key: ${{ runner.os }}-maven-target-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-maven-target-${{ github.sha }}
-      - name: Inject slug vars
-        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
-      - name: Determine tag
-        id: tag
-        run: | # TODO: metadata-action
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "This workflow was triggered by workflow_dispatch."
-            export TAG=${{ github.event.inputs.tag }}
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "This workflow was triggered by a tag push ${GITHUB_REF}"
-            export TAG=$(echo ${GITHUB_REF} | sed 's|^refs/tags/||')
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "This workflow was triggered by a pull request."
-            export TAG=pr-${{ github.event.pull_request.number }}-${GITHUB_HEAD_REF_SLUG}
-          elif [[ "${GITHUB_REF_POINT_SLUG}" == "main" ]]; then
-            export TAG="latest"
-          else
-            export TAG=${GITHUB_REF_POINT_SLUG}
-          fi
-          echo "Image tag will be: ${TAG}"
-          echo "image-tag=${TAG}" >> "${GITHUB_OUTPUT}"
-      - name: Determine image labels
-        # Apply Quay expiry only to branch builds that are not main; tags stay permanent.
-        id: image-labels
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            echo "labels=" >> "${GITHUB_OUTPUT}"
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "labels=" >> "${GITHUB_OUTPUT}"
-          else
-            echo "labels=quay.expires-after=60d" >> "${GITHUB_OUTPUT}"
-          fi
-      - name: Build image tarball
-        run: |
-          LABELS_ARG=""
-          if [[ -n "${{ steps.image-labels.outputs.labels }}" ]]; then
-            LABELS_ARG="-Djib.container.labels=${{ steps.image-labels.outputs.labels }}"
-          fi
-
-          BASE_IMAGE_ARG=""
-          if [[ -n "${{ vars.BASE_IMAGE }}" ]]; then
-            BASE_IMAGE_ARG="-Djib.from.image=${{ vars.BASE_IMAGE }}"
-          fi
-
-          mvn -B jib:buildTar -DskipTests \
-            -Djib.to.image=${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }} \
-            -Djib.to.tags=${{ steps.tag.outputs.image-tag }} \
-            ${BASE_IMAGE_ARG} \
-            ${LABELS_ARG}
-      - name: Save image metadata
-        run: |
-          echo "image-tag=${{ steps.tag.outputs.image-tag }}" > target/image-metadata.env
-          echo "image-name=${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}" >> target/image-metadata.env
-      - name: Upload image artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-        with:
-          name: container-image
-          path: |
-            target/jib-image.tar
-            target/image-metadata.env
-          retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,19 @@ name: Build
 # - REGISTRY_REPO: Repository path (e.g. /tardis-internal/gateway/jumper-sse)
 # - REGISTRY_USER: Container registry username
 # - JAVA_VERSION: Java version to use (defaults to '21' if not specified)
-# - JAVA_DISTRIBUTION: Java distribution to use (defaults to 'temurin' if not specified)
+# - JAVA_DISTRIBUTION: Java distribution to use (defaults to 'zulu' if not specified)
 # - BASE_IMAGE: The base image used for the container build (defaults to gcr.io/distroless/java21-debian12:nonroot)
 #
 # Required secrets:
 # - REGISTRY_TOKEN: Container registry token/password
 # - OSPO_ORT_ARTIFACTORY_CACHE_REPO_KEY: Token for accessing ORT repository
+# - COSIGN_PASSWORD: Cosign key password
+# - COSIGN_PRIVATE_KEY: Cosign private key for image signing
+# - COSIGN_PUBLIC_KEY: Cosign public key for signature verification
+#
+# Required GitHub environment:
+# - "external": Configured with required reviewers. Used as an approval gate
+#   for fork PRs in push-image.yml before pushing with access to secrets.
 
 on:
   pull_request:
@@ -113,13 +120,10 @@ jobs:
           path: |
             **/target/surefire-reports/
 
-  build-push-image:
-    name: Build & push container image
+  build-image:
+    name: Build container image
     runs-on: ubuntu-latest
     needs: [build-maven, test-maven]
-    outputs:
-      image-digest: ${{ steps.build-push.outputs.digest }}
-      image-tag: ${{ steps.tag.outputs.image-tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -168,8 +172,7 @@ jobs:
           else
             echo "labels=quay.expires-after=60d" >> "${GITHUB_OUTPUT}"
           fi
-      - name: Build and push
-        id: build-push
+      - name: Build image tarball
         run: |
           LABELS_ARG=""
           if [[ -n "${{ steps.image-labels.outputs.labels }}" ]]; then
@@ -181,66 +184,20 @@ jobs:
             BASE_IMAGE_ARG="-Djib.from.image=${{ vars.BASE_IMAGE }}"
           fi
 
-          mvn -B jib:build -DskipTests \
+          mvn -B jib:buildTar -DskipTests \
             -Djib.to.image=${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }} \
             -Djib.to.tags=${{ steps.tag.outputs.image-tag }} \
-            -Djib.to.auth.username=${{ vars.REGISTRY_USER }} \
-            -Djib.to.auth.password=${{ secrets.REGISTRY_TOKEN }} \
             ${BASE_IMAGE_ARG} \
             ${LABELS_ARG}
-
-          # Extract the image digest from Jib's output
-          DIGEST=$(cat target/jib-image.digest)
-          echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 #v4.1.2
-        with:
-          cosign-release: "v2.5.3"
-      - name: Sign image using cosign
-        id: cosign-sign
+      - name: Save image metadata
         run: |
-          echo "TAGS=${TAGS}"
-          echo "DIGEST=${DIGEST}"
-          images=""
-          for tag in ${TAGS}; do
-            images+="${{ env.REGISTRY}}${{ env.REGISTRY_REPO }}:${tag}@${DIGEST} "
-          done
-          echo "images=${images}" >> $GITHUB_OUTPUT
-          cosign login -u ${{ env.REGISTRY_USER }} -p ${{ env.REGISTRY_PASSWORD }} ${{ env.REGISTRY }}
-          cosign sign --key env://COSIGN_PRIVATE_KEY --tlog-upload=false ${images}
-        env:
-          TAGS: ${{ steps.tag.outputs.image-tag }}
-          DIGEST: ${{ steps.build-push.outputs.digest }}
-          REGISTRY: ${{ vars.REGISTRY_HOST }}
-          REGISTRY_REPO: ${{ vars.REGISTRY_REPO }}
-          REGISTRY_USER: ${{ vars.REGISTRY_USER }}
-          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_TOKEN }}
-          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-      - name: Verify signature
-        run: |
-          cosign verify --insecure-ignore-tlog=true --key env://COSIGN_PUBLIC_KEY ${IMAGES}
-        env:
-          IMAGES: ${{ steps.cosign-sign.outputs.images }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
-
-  scan-image:
-    name: Scan image
-    runs-on: ubuntu-latest
-    needs: [build-push-image]
-    permissions:
-      contents: write
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
-        env:
-          TRIVY_USERNAME: ${{ vars.REGISTRY_USER }}
-          TRIVY_PASSWORD: ${{ secrets.REGISTRY_TOKEN }}
+          echo "image-tag=${{ steps.tag.outputs.image-tag }}" > target/image-metadata.env
+          echo "image-name=${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}" >> target/image-metadata.env
+      - name: Upload image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
-          image-ref: "${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}@${{ needs.build-push-image.outputs.image-digest }}"
-          exit-code: "0"
-          vuln-type: os # library findings are handled by ort and github auto submission
-          # Only push results to dependency graph if running on main
-          format: ${{ github.event_name == 'pull_request' && 'table' || 'github' }}
-          output: ${{ github.event_name == 'pull_request' && '' || 'dependency-results.sbom.json' }}
-          github-pat: ${{ secrets.GITHUB_TOKEN }}
+          name: container-image
+          path: |
+            target/jib-image.tar
+            target/image-metadata.env
+          retention-days: 1

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,14 +1,15 @@
-# SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom IT GmbH
 #
 # SPDX-License-Identifier: Apache-2.0
 
 name: Push container image
 
 # This workflow runs after the Build workflow completes.
-# It downloads the pre-built image artifact and pushes it to the registry.
+# It checks out the code, builds the container image with Jib, pushes it
+# to the registry, signs it with cosign, and scans it with Trivy.
 #
 # For fork PRs, the "external" environment approval gate ensures a maintainer
-# reviews the fork's code before the image is pushed with access to secrets.
+# reviews the fork's code before the image is built and pushed with secrets.
 # For internal PRs and other events, no approval is required.
 
 on:
@@ -16,49 +17,113 @@ on:
     workflows: ["Build"]
     types: [completed]
 
-permissions: {}
+permissions:
+  contents: read
+  actions: read
+
+env:
+  JAVA_VERSION: ${{ vars.JAVA_VERSION || '21' }}
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'zulu' }}
 
 jobs:
-  push-image:
-    name: Push container image
+  authorize:
+    name: Authorize
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
     if: github.event.workflow_run.conclusion == 'success'
     environment: ${{ github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.head_repository.full_name != github.repository
       && 'external' || '' }}
-    outputs:
-      image-digest: ${{ steps.push.outputs.digest }}
-      image-tag: ${{ steps.metadata.outputs.image-tag }}
     steps:
-      - name: Download image artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+      - run: echo "Authorized to proceed with build and push steps"
+
+  build-push-image:
+    name: Build & push container image
+    runs-on: ubuntu-latest
+    needs: [authorize]
+    outputs:
+      image-digest: ${{ steps.build-push.outputs.digest }}
+      image-tag: ${{ steps.tag.outputs.image-tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          name: container-image
-          path: build-output/
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      - name: Set up JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: "maven"
+      - name: Cache maven target dir
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
+        with:
+          path: target
+          key: ${{ runner.os }}-maven-target-${{ github.event.workflow_run.head_sha || github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-maven-target-${{ github.event.workflow_run.head_sha || github.sha }}
+      - name: Download release tag
+        id: release-tag
+        if: github.event.workflow_run.event == 'workflow_dispatch'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #8.0.1
+        with:
+          name: release-tag
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Read image metadata
-        id: metadata
+          github-token: ${{ github.token }}
+      - name: Determine tag
+        id: tag
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          cat build-output/target/image-metadata.env >> "${GITHUB_OUTPUT}"
-      - name: Login to registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee #v4.2.0
-        with:
-          registry: ${{ vars.REGISTRY_HOST }}
-          username: ${{ vars.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
-      - name: Load and push image
-        id: push
+          if [[ "${{ github.event.workflow_run.event }}" == "workflow_dispatch" ]]; then
+            echo "This workflow was triggered by a release (workflow_dispatch on Build)."
+            export TAG=$(cat release-tag.txt)
+          elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
+            echo "This workflow was triggered by a pull request."
+            PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
+              --head "${HEAD_BRANCH}" --json number --jq '.[0].number')
+            BRANCH_SLUG=$(echo "${HEAD_BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+            export TAG="pr-${PR_NUMBER}-${BRANCH_SLUG}"
+          elif [[ "${HEAD_BRANCH}" == "main" ]]; then
+            export TAG="latest"
+          else
+            export TAG=$(echo "${HEAD_BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+          fi
+          echo "Image tag will be: ${TAG}"
+          echo "image-tag=${TAG}" >> "${GITHUB_OUTPUT}"
+      - name: Determine image labels
+        # Apply Quay expiry only to branch builds that are not main; tags stay permanent.
+        id: image-labels
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          IMAGE_NAME="${{ steps.metadata.outputs.image-name }}"
-          IMAGE_TAG="${{ steps.metadata.outputs.image-tag }}"
+          if [[ "${HEAD_BRANCH}" == "main" ]]; then
+            echo "labels=" >> "${GITHUB_OUTPUT}"
+          else
+            echo "labels=quay.expires-after=60d" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Build and push
+        id: build-push
+        run: |
+          LABELS_ARG=""
+          if [[ -n "${{ steps.image-labels.outputs.labels }}" ]]; then
+            LABELS_ARG="-Djib.container.labels=${{ steps.image-labels.outputs.labels }}"
+          fi
 
-          docker load -i build-output/target/jib-image.tar
-          docker push "${IMAGE_NAME}:${IMAGE_TAG}"
+          BASE_IMAGE_ARG=""
+          if [[ -n "${{ vars.BASE_IMAGE }}" ]]; then
+            BASE_IMAGE_ARG="-Djib.from.image=${{ vars.BASE_IMAGE }}"
+          fi
 
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE_NAME}:${IMAGE_TAG}" | cut -d'@' -f2)
+          mvn -B jib:build -DskipTests \
+            -Djib.to.image=${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }} \
+            -Djib.to.tags=${{ steps.tag.outputs.image-tag }} \
+            -Djib.to.auth.username=${{ vars.REGISTRY_USER }} \
+            -Djib.to.auth.password=${{ secrets.REGISTRY_TOKEN }} \
+            ${BASE_IMAGE_ARG} \
+            ${LABELS_ARG}
+
+          # Extract the image digest from Jib's output
+          DIGEST=$(cat target/jib-image.digest)
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 #v4.1.2
@@ -77,8 +142,8 @@ jobs:
           cosign login -u ${{ env.REGISTRY_USER }} -p ${{ env.REGISTRY_PASSWORD }} ${{ env.REGISTRY }}
           cosign sign --key env://COSIGN_PRIVATE_KEY --tlog-upload=false ${images}
         env:
-          TAGS: ${{ steps.metadata.outputs.image-tag }}
-          DIGEST: ${{ steps.push.outputs.digest }}
+          TAGS: ${{ steps.tag.outputs.image-tag }}
+          DIGEST: ${{ steps.build-push.outputs.digest }}
           REGISTRY: ${{ vars.REGISTRY_HOST }}
           REGISTRY_REPO: ${{ vars.REGISTRY_REPO }}
           REGISTRY_USER: ${{ vars.REGISTRY_USER }}
@@ -95,7 +160,7 @@ jobs:
   scan-image:
     name: Scan image
     runs-on: ubuntu-latest
-    needs: [push-image]
+    needs: [build-push-image]
     permissions:
       contents: write
     steps:
@@ -105,7 +170,7 @@ jobs:
           TRIVY_USERNAME: ${{ vars.REGISTRY_USER }}
           TRIVY_PASSWORD: ${{ secrets.REGISTRY_TOKEN }}
         with:
-          image-ref: "${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}@${{ needs.push-image.outputs.image-digest }}"
+          image-ref: "${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}@${{ needs.build-push-image.outputs.image-digest }}"
           exit-code: "0"
           vuln-type: os # library findings are handled by ort and github auto submission
           # Only push results to dependency graph if running on main

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -55,12 +55,16 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           cache: "maven"
       - name: Cache maven target dir
+        id: cache-target
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
         with:
           path: target
           key: ${{ runner.os }}-maven-target-${{ github.event.workflow_run.head_sha || github.sha }}
           restore-keys: |
             ${{ runner.os }}-maven-target-${{ github.event.workflow_run.head_sha || github.sha }}
+      - name: Compile project
+        if: steps.cache-target.outputs.cache-hit != 'true'
+        run: mvn -B compile -DskipTests
       - name: Download release tag
         id: release-tag
         if: github.event.workflow_run.event == 'workflow_dispatch'

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Push container image
+
+# This workflow runs after the Build workflow completes.
+# It downloads the pre-built image artifact and pushes it to the registry.
+#
+# For fork PRs, the "external" environment approval gate ensures a maintainer
+# reviews the fork's code before the image is pushed with access to secrets.
+# For internal PRs and other events, no approval is required.
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  push-image:
+    name: Push container image
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    if: github.event.workflow_run.conclusion == 'success'
+    environment: ${{ github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.head_repository.full_name != github.repository
+      && 'external' || '' }}
+    outputs:
+      image-digest: ${{ steps.push.outputs.digest }}
+      image-tag: ${{ steps.metadata.outputs.image-tag }}
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: container-image
+          path: build-output/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read image metadata
+        id: metadata
+        run: |
+          cat build-output/target/image-metadata.env >> "${GITHUB_OUTPUT}"
+      - name: Login to registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee #v4.2.0
+        with:
+          registry: ${{ vars.REGISTRY_HOST }}
+          username: ${{ vars.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - name: Load and push image
+        id: push
+        run: |
+          IMAGE_NAME="${{ steps.metadata.outputs.image-name }}"
+          IMAGE_TAG="${{ steps.metadata.outputs.image-tag }}"
+
+          docker load -i build-output/target/jib-image.tar
+          docker push "${IMAGE_NAME}:${IMAGE_TAG}"
+
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE_NAME}:${IMAGE_TAG}" | cut -d'@' -f2)
+          echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 #v4.1.2
+        with:
+          cosign-release: "v2.5.3"
+      - name: Sign image using cosign
+        id: cosign-sign
+        run: |
+          echo "TAGS=${TAGS}"
+          echo "DIGEST=${DIGEST}"
+          images=""
+          for tag in ${TAGS}; do
+            images+="${{ env.REGISTRY}}${{ env.REGISTRY_REPO }}:${tag}@${DIGEST} "
+          done
+          echo "images=${images}" >> $GITHUB_OUTPUT
+          cosign login -u ${{ env.REGISTRY_USER }} -p ${{ env.REGISTRY_PASSWORD }} ${{ env.REGISTRY }}
+          cosign sign --key env://COSIGN_PRIVATE_KEY --tlog-upload=false ${images}
+        env:
+          TAGS: ${{ steps.metadata.outputs.image-tag }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+          REGISTRY: ${{ vars.REGISTRY_HOST }}
+          REGISTRY_REPO: ${{ vars.REGISTRY_REPO }}
+          REGISTRY_USER: ${{ vars.REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_TOKEN }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+      - name: Verify signature
+        run: |
+          cosign verify --insecure-ignore-tlog=true --key env://COSIGN_PUBLIC_KEY ${IMAGES}
+        env:
+          IMAGES: ${{ steps.cosign-sign.outputs.images }}
+          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+
+  scan-image:
+    name: Scan image
+    runs-on: ubuntu-latest
+    needs: [push-image]
+    permissions:
+      contents: write
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ vars.REGISTRY_USER }}
+          TRIVY_PASSWORD: ${{ secrets.REGISTRY_TOKEN }}
+        with:
+          image-ref: "${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}@${{ needs.push-image.outputs.image-digest }}"
+          exit-code: "0"
+          vuln-type: os # library findings are handled by ort and github auto submission
+          # Only push results to dependency graph if running on main
+          format: ${{ github.event.workflow_run.event == 'pull_request' && 'table' || 'github' }}
+          output: ${{ github.event.workflow_run.event == 'pull_request' && '' || 'dependency-results.sbom.json' }}
+          github-pat: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I split the image build and push to get the access to secrets. This is necessary to make sure the code of the fork is never executed while having access to secrets. Also a maintainer needs to approve the push step for the fork PR.

I already created the environment "external" with "telekom/gateway" as required approval.

This also removes the layer caching from jib and for now i couldn't find a workaround.