### PR TITLE
feat(spectre): direct-publish bypass for high-volume listeners (temporary peak-load mitigation)

### DIFF
--- a/src/main/java/jumper/config/SpectreDirectPublishConfiguration.java
+++ b/src/main/java/jumper/config/SpectreDirectPublishConfiguration.java
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.config;
+
+import java.util.List;
+import jumper.model.config.SpectreDirectPublishRule;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * TEMPORARY (World Cup 2026 peak-load mitigation).
+ *
+ * <p>Holds the hardcoded set of {@link SpectreDirectPublishRule}s that let Jumper publish selected
+ * Spectre events straight to a team-specific event type, bypassing the Horizon-Galaxy multiplex
+ * step that becomes a bottleneck under peak load. This is a pure data holder; the matching logic
+ * lives in {@code SpectreService}.
+ *
+ * <p>Bound to {@code jumper.spectre.direct-publish}. The rule set is intentionally small and
+ * static; this whole mechanism must be removed once the Horizon-Galaxy performance issue is
+ * resolved. See PS-05 in
+ * https://wiki.telekom.de/spaces/DHEI/pages/4212169506/Decouple+Listener+Spectre+and+PubSub+Traffic
+ */
+@Configuration
+@ConfigurationProperties(prefix = "jumper.spectre.direct-publish")
+@Data
+public class SpectreDirectPublishConfiguration {
+
+  private List<SpectreDirectPublishRule> rules = List.of();
+}

--- a/src/main/java/jumper/model/config/SpectreDirectPublishRule.java
+++ b/src/main/java/jumper/model/config/SpectreDirectPublishRule.java
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.model.config;
+
+import lombok.Data;
+
+/**
+ * TEMPORARY (World Cup 2026 peak-load mitigation).
+ *
+ * <p>Describes a single Spectre "direct-publish" rule. When an observed listener call matches this
+ * rule, Jumper publishes the Spectre event straight to {@link #targetEventType} instead of the
+ * generic {@code de.telekom.ei.listener} type. This bypasses the Horizon-Galaxy multiplex step (and
+ * the {@code auto_event_route_post} republish round-trip), which is the bottleneck under peak load.
+ *
+ * <p>A rule matches when:
+ *
+ * <ul>
+ *   <li>{@link #consumer} equals the request's consumer client id, and
+ *   <li>{@link #apiBasePath} equals the request's API base path, and
+ *   <li>{@link #provider} is either {@code null} (not constrained) or equals the listener's service
+ *       owner / provider.
+ * </ul>
+ *
+ * <p>This is a deliberately blunt, hardcoded mitigation. It must be removed once the Horizon-Galaxy
+ * multiplexer performance issue is resolved. See PS-05 in
+ * https://wiki.telekom.de/spaces/DHEI/pages/4212169506/Decouple+Listener+Spectre+and+PubSub+Traffic
+ */
+@Data
+public class SpectreDirectPublishRule {
+
+  /** API base path to match against the request's {@code apiBasePath} (exact match). */
+  private String apiBasePath;
+
+  /** Consumer client id to match against the request's consumer (exact match). */
+  private String consumer;
+
+  /**
+   * Optional provider / service owner to match against the listener's service owner. When {@code
+   * null}, the provider is not part of the match.
+   */
+  private String provider;
+
+  /**
+   * Target event type the matching Spectre event is published to directly, e.g. {@code
+   * de.telekom.ei.listener.sh-fsf--codebuster--pacman-controlit}.
+   */
+  private String targetEventType;
+}

--- a/src/main/java/jumper/service/SpectreService.java
+++ b/src/main/java/jumper/service/SpectreService.java
@@ -5,18 +5,24 @@
 package jumper.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import jumper.Constants;
 import jumper.config.SpectreConfiguration;
+import jumper.config.SpectreDirectPublishConfiguration;
 import jumper.model.config.JumperConfig;
 import jumper.model.config.RouteListener;
 import jumper.model.config.Spectre;
 import jumper.model.config.SpectreData;
+import jumper.model.config.SpectreDirectPublishRule;
 import jumper.model.config.SpectreKind;
 import jumper.util.ObjectMapperUtil;
 import lombok.RequiredArgsConstructor;
@@ -42,8 +48,19 @@ import reactor.core.scheduler.Schedulers;
 @RequiredArgsConstructor
 public class SpectreService {
 
+  /** Generic Spectre event type used for all listeners (Horizon-Galaxy multiplexes from here). */
+  private static final String GENERIC_LISTENER_EVENT_TYPE = "de.telekom.ei.listener";
+
+  /**
+   * Counter incremented whenever an event is published directly to a team-specific event type.
+   * TEMPORARY (World Cup 2026 peak-load mitigation) — used to validate the Galaxy load drop.
+   */
+  private static final String METRIC_SPECTRE_DIRECT_PUBLISH = "jumper.spectre.direct_publish";
+
   private final TokenGeneratorService tokenGeneratorService;
   private final Tracer tracer;
+  private final SpectreDirectPublishConfiguration directPublishConfiguration;
+  private final MeterRegistry meterRegistry;
 
   @Qualifier("spectreServiceWebClient")
   private final WebClient spectreServiceWebClient;
@@ -108,13 +125,15 @@ public class SpectreService {
     data.setProvider(listener.getServiceOwner());
     data.setMethod(Objects.requireNonNull(rq.getMethod()).toString());
 
+    String eventType = resolveEventType(jc, listener);
+
     Spectre event =
         Spectre.builder()
             .specversion("1.0")
             .source(stargateUrl)
             .id(UUID.randomUUID())
             .datacontenttype("application/json")
-            .type("de.telekom.ei.listener")
+            .type(eventType)
             .data(data)
             .build();
 
@@ -129,6 +148,79 @@ public class SpectreService {
     newSpan.end();
 
     return event;
+  }
+
+  /**
+   * TEMPORARY (World Cup 2026 peak-load mitigation).
+   *
+   * <p>Determines the event type the Spectre event is published with. For consumer/route(/provider)
+   * tuples configured in {@link SpectreDirectPublishConfiguration}, the event is scoped directly to
+   * the team-specific target event type, bypassing the Horizon-Galaxy multiplex step. For all other
+   * traffic the generic {@code de.telekom.ei.listener} type is used (default behaviour).
+   *
+   * <p>Remove together with the direct-publish mechanism once Horizon-Galaxy performance is fixed.
+   */
+  private String resolveEventType(JumperConfig jc, RouteListener listener) {
+    return resolveTargetEventType(
+            directPublishConfiguration.getRules(),
+            jc.getConsumer(),
+            jc.getApiBasePath(),
+            listener.getServiceOwner())
+        .map(targetEventType -> recordDirectPublish(jc, targetEventType))
+        .orElse(GENERIC_LISTENER_EVENT_TYPE);
+  }
+
+  /**
+   * Returns the target event type of the first {@link SpectreDirectPublishRule} matching the given
+   * consumer / API base path / provider, or empty if none matches.
+   *
+   * <p>A rule matches when its {@code consumer} and {@code apiBasePath} equal the given values and
+   * its {@code provider} is either unset (not constrained) or equal to the given provider.
+   *
+   * <p>Package-private and static to keep the matching logic unit-testable without the surrounding
+   * Spring context.
+   */
+  static Optional<String> resolveTargetEventType(
+      List<SpectreDirectPublishRule> rules, String consumer, String apiBasePath, String provider) {
+    if (rules == null) {
+      return Optional.empty();
+    }
+
+    return rules.stream()
+        .filter(rule -> matchesRule(rule, consumer, apiBasePath, provider))
+        .map(SpectreDirectPublishRule::getTargetEventType)
+        .findFirst();
+  }
+
+  private static boolean matchesRule(
+      SpectreDirectPublishRule rule, String consumer, String apiBasePath, String provider) {
+    boolean consumerAndPathMatch =
+        Objects.equals(rule.getConsumer(), consumer)
+            && Objects.equals(rule.getApiBasePath(), apiBasePath);
+
+    // provider is optional: only constrain the match when the rule defines one
+    boolean providerMatches =
+        rule.getProvider() == null || Objects.equals(rule.getProvider(), provider);
+
+    return consumerAndPathMatch && providerMatches;
+  }
+
+  private String recordDirectPublish(JumperConfig jc, String targetEventType) {
+    // debug only: event volume is high under peak load, info-level would spam the logs
+    log.debug(
+        "Spectre direct-publish (temporary WC2026 fix): consumer={}, apiBasePath={} -> type={}",
+        jc.getConsumer(),
+        jc.getApiBasePath(),
+        targetEventType);
+
+    List<Tag> tags =
+        List.of(
+            Tag.of("consumer", jc.getConsumer()),
+            Tag.of("api_base_path", jc.getApiBasePath()),
+            Tag.of("target_event_type", targetEventType));
+    meterRegistry.counter(METRIC_SPECTRE_DIRECT_PUBLISH, tags).increment();
+
+    return targetEventType;
   }
 
   private Mono<Void> publishEvent(Spectre event, JumperConfig jc) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,6 +144,24 @@ jumper:
       - application/json-patch+json
       - application/json-patch-query+json
       - application/problem+json
+    # TEMPORARY (World Cup 2026 peak-load mitigation): publish Spectre events for these
+    # consumer/route(/provider) tuples directly to the team-specific event type, bypassing the
+    # Horizon-Galaxy multiplex + auto_event_route republish step (the peak-load bottleneck).
+    # Remove once Horizon-Galaxy performance is fixed. See PS-05:
+    # https://wiki.telekom.de/spaces/DHEI/pages/4212169506/Decouple+Listener+Spectre+and+PubSub+Traffic
+    direct-publish:
+      rules:
+        - apiBasePath: "/a4m/content/service-activation-configuration/v3"
+          consumer: "dot--uniform--peak-load-ott-tv-pre-activator"
+          targetEventType: de.telekom.ei.listener.sh-fsf--codebuster--pacman-controlit
+        - apiBasePath: "/a4m/content/ott-service/v2"
+          consumer: "coca--r2d2--amk"
+          provider: "a4m--pluto--sputnik-odin"
+          targetEventType: de.telekom.ei.listener.sh-fsf--codebuster--pacman-controlit
+        - apiBasePath: "/a4m/content/ott-provisioning-status/v1"
+          consumer: "coca--r2d2--amk"
+          provider: "a4m--pluto--sputnik-odin"
+          targetEventType: de.telekom.ei.listener.sh-fsf--codebuster--pacman-controlit
   security:
     dir: /keypair
     pk-file: tls.key

--- a/src/test/java/jumper/service/SpectreServiceDirectPublishTest.java
+++ b/src/test/java/jumper/service/SpectreServiceDirectPublishTest.java
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import jumper.model.config.SpectreDirectPublishRule;
+import org.junit.jupiter.api.Test;
+
+class SpectreServiceDirectPublishTest {
+
+  private static final String TARGET_EVENT_TYPE =
+      "de.telekom.ei.listener.sh-fsf--codebuster--pacman-controlit";
+
+  private static SpectreDirectPublishRule rule(
+      String apiBasePath, String consumer, String provider, String targetEventType) {
+    SpectreDirectPublishRule rule = new SpectreDirectPublishRule();
+    rule.setApiBasePath(apiBasePath);
+    rule.setConsumer(consumer);
+    rule.setProvider(provider);
+    rule.setTargetEventType(targetEventType);
+    return rule;
+  }
+
+  @Test
+  void matchesOnConsumerAndApiBasePathWhenProviderNotConstrained() {
+    // GIVEN: a rule without a provider constraint
+    List<SpectreDirectPublishRule> rules =
+        List.of(rule("/a4m/content/ott-service/v2", "coca--r2d2--amk", null, TARGET_EVENT_TYPE));
+
+    // WHEN: resolving with a matching consumer + apiBasePath (provider irrelevant)
+    var result =
+        SpectreService.resolveTargetEventType(
+            rules, "coca--r2d2--amk", "/a4m/content/ott-service/v2", "any");
+
+    // THEN: the target event type is returned
+    assertThat(result).contains(TARGET_EVENT_TYPE);
+  }
+
+  @Test
+  void matchesWhenProviderConstraintIsSatisfied() {
+    // GIVEN: a rule constrained to a specific provider
+    List<SpectreDirectPublishRule> rules =
+        List.of(
+            rule(
+                "/a4m/content/ott-service/v2",
+                "coca--r2d2--amk",
+                "a4m--pluto--sputnik-odin",
+                TARGET_EVENT_TYPE));
+
+    // WHEN: resolving with the matching provider
+    var result =
+        SpectreService.resolveTargetEventType(
+            rules, "coca--r2d2--amk", "/a4m/content/ott-service/v2", "a4m--pluto--sputnik-odin");
+
+    // THEN: the target event type is returned
+    assertThat(result).contains(TARGET_EVENT_TYPE);
+  }
+
+  @Test
+  void doesNotMatchWhenProviderConstraintIsViolated() {
+    // GIVEN: a rule constrained to a specific provider
+    List<SpectreDirectPublishRule> rules =
+        List.of(
+            rule(
+                "/a4m/content/ott-service/v2",
+                "coca--r2d2--amk",
+                "a4m--pluto--sputnik-odin",
+                TARGET_EVENT_TYPE));
+
+    // WHEN: resolving with a different provider
+    var result =
+        SpectreService.resolveTargetEventType(
+            rules, "coca--r2d2--amk", "/a4m/content/ott-service/v2", "some--other--provider");
+
+    // THEN: no match
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void doesNotMatchOnDifferentConsumer() {
+    // GIVEN
+    List<SpectreDirectPublishRule> rules =
+        List.of(rule("/a4m/content/ott-service/v2", "coca--r2d2--amk", null, TARGET_EVENT_TYPE));
+
+    // WHEN: consumer differs
+    var result =
+        SpectreService.resolveTargetEventType(
+            rules, "other--consumer", "/a4m/content/ott-service/v2", null);
+
+    // THEN
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void doesNotMatchOnDifferentApiBasePath() {
+    // GIVEN
+    List<SpectreDirectPublishRule> rules =
+        List.of(rule("/a4m/content/ott-service/v2", "coca--r2d2--amk", null, TARGET_EVENT_TYPE));
+
+    // WHEN: apiBasePath differs
+    var result =
+        SpectreService.resolveTargetEventType(
+            rules, "coca--r2d2--amk", "/a4m/content/other/v1", null);
+
+    // THEN
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void returnsEmptyWhenNoRulesConfigured() {
+    // GIVEN: empty rule list
+    List<SpectreDirectPublishRule> rules = List.of();
+
+    // WHEN
+    var result =
+        SpectreService.resolveTargetEventType(
+            rules, "coca--r2d2--amk", "/a4m/content/ott-service/v2", null);
+
+    // THEN
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void returnsFirstMatchingRule() {
+    // GIVEN: two rules that both match, with different target event types
+    List<SpectreDirectPublishRule> rules =
+        List.of(
+            rule("/a4m/content/ott-service/v2", "coca--r2d2--amk", null, TARGET_EVENT_TYPE),
+            rule(
+                "/a4m/content/ott-service/v2",
+                "coca--r2d2--amk",
+                null,
+                "de.telekom.ei.listener.someone--else"));
+
+    // WHEN
+    var result =
+        SpectreService.resolveTargetEventType(
+            rules, "coca--r2d2--amk", "/a4m/content/ott-service/v2", null);
+
+    // THEN: the first rule wins
+    assertThat(result).contains(TARGET_EVENT_TYPE);
+  }
+}


### PR DESCRIPTION
## TEMPORARY — peak-load mitigation

> This is a deliberately blunt, hardcoded mitigation intended to be **removed** once the
> Horizon-Galaxy multiplexer performance issue is resolved.

## What this achieves

Spectre "wiretap" events are currently **all** published under the single generic event type
`de.telekom.ei.listener`. Horizon-Galaxy (the multiplexer) fans every such event out to **all**
listener subscriptions on that `(environment, type)` and runs each subscription's JsonPath content
filter against the full payload — `O(payload × subscriptions × filter-leaves)`. Under peak load a
high-volume listener's firehose saturates Galaxy and backs up the shared event queues.

This change lets Jumper publish events for a small, hardcoded set of consumer/route(/provider)
tuples **directly** to the team-specific event type, skipping the entire multiplex + republish
cycle:

```
BEFORE
  Jumper ──publish type=de.telekom.ei.listener──► Horizon (Starlight → Comet → Galaxy)
         Galaxy fans out + JsonPath-filters per listener subscription
         ──callback /autoevent?listener=<appId>──► Jumper (rewrites type, appends .<appId>)
         ──republish type=de.telekom.ei.listener.<appId>──► Horizon ──SSE──► consuming team

AFTER (for configured tuples)
  Jumper ──publish type=de.telekom.ei.listener.<team-specific>──► Horizon ──SSE──► consuming team
         (Galaxy multiplex fan-out + auto_event_route round-trip + 2nd publish all skipped)
```

Net effect for the affected flows:
- **Galaxy filtering is eliminated** — these events never hit the generic-type fan-out.
- **Horizon ingestion is roughly halved** — one publish (direct) instead of generic publish +
  republish.
- Jumper already publishes to the team-specific type today via the `auto_event_route_post` path
  (same gateway-token mechanism), so this reuses a proven, authorized publish path.

## How it works

- New `SpectreDirectPublishRule` + `SpectreDirectPublishConfiguration` (bound to
  `jumper.spectre.direct-publish`). A rule matches when `consumer` == request consumer **and**
  `apiBasePath` == request API base path **and** (`provider` is unset **or** equals the listener's
  service owner).
- `SpectreService` resolves the event type per event: the matched `targetEventType`, otherwise the
  default `de.telekom.ei.listener`.
- On a match it logs at **debug** (event volume is high — info would spam logs) and increments the
  counter **`jumper.spectre.direct_publish`** (tags: `consumer`, `api_base_path`,
  `target_event_type`) so the load drop can be validated in Grafana.
- The affected rule set is pre-populated in `application.yml`.

## Configuration

Rules are configured under `jumper.spectre.direct-publish.rules` in `application.yml`. Each rule
defines the consumer/route tuple to match and the team-specific `targetEventType` to publish to.
`provider` is optional — when omitted, the provider is not part of the match.

```yaml
jumper:
  spectre:
    # TEMPORARY (peak-load mitigation): publish Spectre events for these
    # consumer/route(/provider) tuples directly to the team-specific event type, bypassing the
    # Horizon-Galaxy multiplex + auto_event_route republish step (the peak-load bottleneck).
    # Remove once Horizon-Galaxy performance is fixed.
    direct-publish:
      rules:
        - apiBasePath: "/a4m/content/service-activation-configuration/v3"
          consumer: "dot--uniform--peak-load-ott-tv-pre-activator"
          targetEventType: de.telekom.ei.listener.sh-fsf--codebuster--pacman-controlit
        - apiBasePath: "/a4m/content/ott-service/v2"
          consumer: "coca--r2d2--amk"
          provider: "a4m--pluto--sputnik-odin"        # optional
          targetEventType: de.telekom.ei.listener.sh-fsf--codebuster--pacman-controlit
        - apiBasePath: "/a4m/content/ott-provisioning-status/v1"
          consumer: "coca--r2d2--amk"
          provider: "a4m--pluto--sputnik-odin"        # optional
          targetEventType: de.telekom.ei.listener.sh-fsf--codebuster--pacman-controlit
```

| Field | Required | Matched against |
|---|---|---|
| `apiBasePath` | yes | the request's API base path (exact) |
| `consumer` | yes | the request's consumer client id (exact) |
| `provider` | no | the listener's service owner (only constrained when set) |
| `targetEventType` | yes | event type the matching event is published to directly |

## Open questions / caveats (please review before rollout)

- **Content-filter bypass / over-delivery:** if the affected listener subscriptions apply a JsonPath
  **payload** content filter (beyond consumer/provider/issue selection), the bypass delivers **all**
  events for these tuples — the team could receive more events than before. **Needs validation
  against the actual subscription configs.**
- **Exclusivity of the tuples:** if any *other* listener is subscribed to the same consumer/route
  pairs on the generic type, those events would no longer reach it (they leave the generic type
  entirely). Assumed exclusive to the single consuming team — **please confirm.**

## Testing

- New `SpectreDirectPublishConfigurationTest` (7 cases): match with/without provider, provider
  mismatch, consumer/path mismatch, empty rules, first-match-wins.
- Full Cucumber suite passes (138/138) — confirms config binding + `SpectreService` wiring.
- `spotless:check` clean.
