### PR TITLE
feat: enable gateway metrics with custom SLO buckets

### DIFF
--- a/src/main/java/jumper/config/TracingConfiguration.java
+++ b/src/main/java/jumper/config/TracingConfiguration.java
@@ -88,6 +88,8 @@ public class TracingConfiguration {
 
     gatewayContext.removeLowCardinalityKeyValue("spring.cloud.gateway.route.id");
     gatewayContext.removeLowCardinalityKeyValue("spring.cloud.gateway.route.uri");
+    moveLowToHighCardinality(gatewayContext, "http.method");
+    moveLowToHighCardinality(gatewayContext, "http.status_code");
 
     String xTardisTraceId = request.getHeaders().getFirst(Constants.HEADER_X_TARDIS_TRACE_ID);
     appendXTardisTraceIdHeader(gatewayContext, xTardisTraceId);
@@ -110,6 +112,14 @@ public class TracingConfiguration {
 
     String xTardisTraceId = request.headers().getFirst(Constants.HEADER_X_TARDIS_TRACE_ID);
     appendXTardisTraceIdHeader(clientRequestContext, xTardisTraceId);
+  }
+
+  private static void moveLowToHighCardinality(Observation.Context context, String key) {
+    KeyValue kv = context.getLowCardinalityKeyValue(key);
+    if (kv != null) {
+      context.removeLowCardinalityKeyValue(key);
+      context.addHighCardinalityKeyValue(kv);
+    }
   }
 
   private static void appendXTardisTraceIdHeader(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,11 @@ management:
   #   TRACING_EXPORTER=otlp   -> application-otlp.yml
   #   TRACING_EXPORTER=zipkin -> application-zipkin.yml (default)
   # The chart sets TRACING_EXPORTER; locally it defaults to zipkin.
+  metrics:
+    distribution:
+      slo:
+        spring.cloud.gateway.http.client.requests: 1ms,2ms,5ms,10ms,20ms,50ms,100ms,200ms,500ms,1000ms,2000ms,5000ms,10000ms,30000ms,60000ms
+
 
 cache-manager:
   caffeine-caches:
@@ -68,6 +73,8 @@ spring:
     name: ${JUMPER_NAME:jumper}
   cloud:
     gateway:
+      metrics:
+        enabled: true
       server:
         webflux:
           forwarded:


### PR DESCRIPTION
- Enable Spring Cloud Gateway metrics collection
- Configure custom SLO distribution buckets for gateway request latencies ranging from 1ms to 60s
- moved http.status_code and http.method to high cardinality to keep it in traces but skip it from metrics to prevent high cardinatlity in metrics

example will be flat:

```
# TYPE spring_cloud_gateway_http_client_requests_seconds histogram
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.001"} 0
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.002"} 0
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.005"} 0
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.01"} 0
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.02"} 3
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.05"} 7
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.1"} 12
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.2"} 19
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="0.5"} 23
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="1.0"} 24
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="2.0"} 24
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="5.0"} 24
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="10.0"} 24
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="30.0"} 24
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="60.0"} 24
spring_cloud_gateway_http_client_requests_seconds_bucket{error="none",le="+Inf"} 24
spring_cloud_gateway_http_client_requests_seconds_count{error="none"} 24
spring_cloud_gateway_http_client_requests_seconds_sum{error="none"} 3.15798717
```