### PR TITLE
fix(zone-health): use PING instead of INFO for Redis health check

### DIFF
--- a/src/main/java/jumper/job/RedisHealthCheck.java
+++ b/src/main/java/jumper/job/RedisHealthCheck.java
@@ -63,7 +63,9 @@ public class RedisHealthCheck {
     if (connection instanceof RedisClusterConnection) {
       ((RedisClusterConnection) connection).clusterGetClusterInfo();
     } else {
-      connection.serverCommands().info("server");
+      // Use PING (category @fast/@connection) instead of INFO (category @dangerous)
+      // so the health check works with hardened Valkey/Redis ACLs (e.g. +@all -@dangerous).
+      connection.ping();
     }
   }
 


### PR DESCRIPTION
RedisHealthCheck issued INFO to probe the connection. INFO is in the '@dangerous' command category and is rejected by hardened Valkey/Redis ACLs (e.g. +@all -@dangerous), causing the zone.health.redis.connection gauge to report disconnected even though pub/sub was working.

Use PING (category @fast/@connection) for the standalone health check, which works under restricted ACLs and accurately reflects connectivity.