### PR TITLE
feat: restore gateway metrics SLO buckets dropped in SB4 migration

### DIFF
--- a/src/main/java/jumper/config/TracingConfiguration.java
+++ b/src/main/java/jumper/config/TracingConfiguration.java
@@ -89,8 +89,19 @@ public class TracingConfiguration {
     gatewayContext.removeLowCardinalityKeyValue("spring.cloud.gateway.route.id");
     gatewayContext.removeLowCardinalityKeyValue("spring.cloud.gateway.route.uri");
 
+    moveLowToHighCardinality(gatewayContext, "http.method");
+    moveLowToHighCardinality(gatewayContext, "http.status_code");
+
     String xTardisTraceId = request.getHeaders().getFirst(Constants.HEADER_X_TARDIS_TRACE_ID);
     appendXTardisTraceIdHeader(gatewayContext, xTardisTraceId);
+  }
+
+  private static void moveLowToHighCardinality(Observation.Context context, String key) {
+    KeyValue kv = context.getLowCardinalityKeyValue(key);
+    if (kv != null) {
+      context.removeLowCardinalityKeyValue(key);
+      context.addHighCardinalityKeyValue(kv);
+    }
   }
 
   private void handleClientRequestContext(ClientRequestObservationContext clientRequestContext) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,10 @@ management:
       # header flow) across the mesh. Export format (OTLP or Zipkin) is
       # independent of wire propagation (B3).
       type: B3_MULTI
+  metrics:
+    distribution:
+      slo:
+        spring.cloud.gateway.http.client.requests: 1ms,2ms,5ms,10ms,20ms,50ms,100ms,200ms,500ms,1000ms,2000ms,5000ms,10000ms,30000ms,60000ms
   # Trace exporter selection is profile-driven so exactly one exporter is active
   # at runtime, even though both exporter libraries are on the classpath:
   #   TRACING_EXPORTER=otlp   -> application-otlp.yml


### PR DESCRIPTION
## What

Restores the changes from #127 that were accidentally dropped during the Spring Boot 4 migration (#125).

## Why

#125 branched off a base that already included #127, but regenerated `application.yml` and `TracingConfiguration.java` without these lines, silently dropping them. Confirmed via `git show`: the migration commit removed the exact PR #127 lines.

- `spring.cloud.gateway...metrics.enabled` survived (migrated to `server.webflux.metrics.enabled`).
- The SLO distribution buckets and the low->high cardinality remapping were lost.

(For reference: #131's Redis PING health-check change survived the migration and needs no action.)

## Changes

- `application.yml`: restore `management.metrics.distribution.slo` for `spring.cloud.gateway.http.client.requests` (1ms..60s).
- `TracingConfiguration.java`: restore `moveLowToHighCardinality(http.method / http.status_code)`.

## Meter-name verification

The SLO key `spring.cloud.gateway.http.client.requests` matches the project's custom `GatewayObservationConvention` bean, whose `getName()` renames the gateway observation meter to that value (bean survived the migration). Stock Gateway would name it `http.client.requests`; the override makes the key bind correctly.

## Verification

- `./mvnw clean test` -> 290 tests, 0 failures, 0 errors
- `./mvnw spotless:check` -> pass

Commit authored by the original #127 author (Christian Ingenhaag).