### PR TITLE
fix(tracing): restore exporter configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@ SPDX-License-Identifier: Apache-2.0
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-zipkin</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing-bridge-otel</artifactId>
 		</dependency>

--- a/src/main/resources/application-otlp.yml
+++ b/src/main/resources/application-otlp.yml
@@ -12,12 +12,14 @@ spring:
       - org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.zipkin.ZipkinWithOpenTelemetryTracingAutoConfiguration
 
 management:
-  otlp:
+  opentelemetry:
     tracing:
-      # OTLP/HTTP exporter. TRACING_URL must be the FULL OTLP traces endpoint
-      # INCLUDING the path, e.g. http://otel-collector:4318/v1/traces. The chart
-      # passes global.tracing.collectorUrl verbatim (no trim/append), so Kong
-      # and Jumper share the exact same URL. For gRPC (port 4317) set
-      # transport: grpc instead.
-      endpoint: ${TRACING_URL:http://localhost:4318/v1/traces}
-      transport: http
+      export:
+        otlp:
+          # OTLP/HTTP exporter. TRACING_URL must be the FULL OTLP traces endpoint
+          # INCLUDING the path, e.g. http://otel-collector:4318/v1/traces. The chart
+          # passes global.tracing.collectorUrl verbatim (no trim/append), so Kong
+          # and Jumper share the exact same URL. For gRPC (port 4317) set
+          # transport: grpc instead.
+          endpoint: ${TRACING_URL:http://localhost:4318/v1/traces}
+          transport: http

--- a/src/main/resources/application-otlp.yml
+++ b/src/main/resources/application-otlp.yml
@@ -9,6 +9,7 @@
 spring:
   autoconfigure:
     exclude:
+      - org.springframework.boot.zipkin.autoconfigure.ZipkinAutoConfiguration
       - org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.zipkin.ZipkinWithOpenTelemetryTracingAutoConfiguration
 
 management:

--- a/src/main/resources/application-zipkin.yml
+++ b/src/main/resources/application-zipkin.yml
@@ -18,6 +18,7 @@ spring:
       - org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.otlp.OtlpTracingAutoConfiguration
 
 management:
-  zipkin:
-    tracing:
-      endpoint: ${TRACING_URL:http://localhost:9411/api/v2/spans}
+  tracing:
+    export:
+      zipkin:
+        endpoint: ${TRACING_URL:http://localhost:9411/api/v2/spans}

--- a/src/test/java/jumper/config/TracingOtlpExporterProfileTest.java
+++ b/src/test/java/jumper/config/TracingOtlpExporterProfileTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.otlp.OtlpTracingProperties;
 import org.springframework.boot.micrometer.tracing.test.autoconfigure.AutoConfigureTracing;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
@@ -23,7 +24,9 @@ import org.springframework.test.context.ActiveProfiles;
  * <p>The actual {@code SpanExporter} beans are not instantiated under
  * {@code @AutoConfigureTracing}, so the auto-configuration class beans are asserted instead.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = "TRACING_URL=http://collector.example:4318/v1/traces")
 @ActiveProfiles({"test", "otlp"})
 @AutoConfigureTracing
 class TracingOtlpExporterProfileTest {
@@ -37,6 +40,8 @@ class TracingOtlpExporterProfileTest {
 
   @Autowired private ApplicationContext context;
 
+  @Autowired private OtlpTracingProperties otlpTracingProperties;
+
   @Test
   void otlpTracingAutoConfigurationActiveAndZipkinExcluded() {
     assertThat(context.containsBean(OTLP_TRACING_AUTOCONFIG))
@@ -46,5 +51,11 @@ class TracingOtlpExporterProfileTest {
         .withFailMessage(
             "Zipkin tracing auto-configuration must be excluded under the 'otlp' profile")
         .isFalse();
+  }
+
+  @Test
+  void otlpEndpointUsesTracingUrl() {
+    assertThat(otlpTracingProperties.getEndpoint())
+        .isEqualTo("http://collector.example:4318/v1/traces");
   }
 }

--- a/src/test/java/jumper/config/TracingOtlpExporterProfileTest.java
+++ b/src/test/java/jumper/config/TracingOtlpExporterProfileTest.java
@@ -37,6 +37,8 @@ class TracingOtlpExporterProfileTest {
   private static final String ZIPKIN_TRACING_AUTOCONFIG =
       "org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.zipkin"
           + ".ZipkinWithOpenTelemetryTracingAutoConfiguration";
+  private static final String ZIPKIN_AUTOCONFIG =
+      "org.springframework.boot.zipkin.autoconfigure.ZipkinAutoConfiguration";
 
   @Autowired private ApplicationContext context;
 
@@ -50,6 +52,10 @@ class TracingOtlpExporterProfileTest {
     assertThat(context.containsBean(ZIPKIN_TRACING_AUTOCONFIG))
         .withFailMessage(
             "Zipkin tracing auto-configuration must be excluded under the 'otlp' profile")
+        .isFalse();
+    assertThat(context.containsBean(ZIPKIN_AUTOCONFIG))
+        .withFailMessage(
+            "Zipkin sender auto-configuration must be excluded under the 'otlp' profile")
         .isFalse();
   }
 

--- a/src/test/java/jumper/config/TracingZipkinExporterProfileTest.java
+++ b/src/test/java/jumper/config/TracingZipkinExporterProfileTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.micrometer.tracing.test.autoconfigure.AutoConfigureTracing;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.zipkin.autoconfigure.ZipkinProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -24,7 +25,9 @@ import org.springframework.test.context.ActiveProfiles;
  * <p>The actual {@code SpanExporter} beans are not instantiated under
  * {@code @AutoConfigureTracing}, so the auto-configuration class beans are asserted instead.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = "TRACING_URL=http://collector.example:9411/api/v2/spans")
 @ActiveProfiles({"test", "zipkin"})
 @AutoConfigureTracing
 class TracingZipkinExporterProfileTest {
@@ -38,6 +41,8 @@ class TracingZipkinExporterProfileTest {
 
   @Autowired private ApplicationContext context;
 
+  @Autowired private ZipkinProperties zipkinProperties;
+
   @Test
   void zipkinTracingAutoConfigurationActiveAndOtlpExcluded() {
     assertThat(context.containsBean(ZIPKIN_TRACING_AUTOCONFIG))
@@ -48,5 +53,11 @@ class TracingZipkinExporterProfileTest {
         .withFailMessage(
             "OTLP tracing auto-configuration must be excluded under the 'zipkin' profile")
         .isFalse();
+  }
+
+  @Test
+  void zipkinEndpointUsesTracingUrl() {
+    assertThat(zipkinProperties.getEndpoint())
+        .isEqualTo("http://collector.example:9411/api/v2/spans");
   }
 }

--- a/src/test/java/jumper/config/TracingZipkinExporterProfileTest.java
+++ b/src/test/java/jumper/config/TracingZipkinExporterProfileTest.java
@@ -38,6 +38,8 @@ class TracingZipkinExporterProfileTest {
   private static final String ZIPKIN_TRACING_AUTOCONFIG =
       "org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.zipkin"
           + ".ZipkinWithOpenTelemetryTracingAutoConfiguration";
+  private static final String ZIPKIN_AUTOCONFIG =
+      "org.springframework.boot.zipkin.autoconfigure.ZipkinAutoConfiguration";
 
   @Autowired private ApplicationContext context;
 
@@ -48,6 +50,10 @@ class TracingZipkinExporterProfileTest {
     assertThat(context.containsBean(ZIPKIN_TRACING_AUTOCONFIG))
         .withFailMessage(
             "Zipkin tracing auto-configuration must be active under the 'zipkin' profile")
+        .isTrue();
+    assertThat(context.containsBean(ZIPKIN_AUTOCONFIG))
+        .withFailMessage(
+            "Zipkin sender auto-configuration must be active under the 'zipkin' profile")
         .isTrue();
     assertThat(context.containsBean(OTLP_TRACING_AUTOCONFIG))
         .withFailMessage(


### PR DESCRIPTION
## Summary
- update OTLP and Zipkin tracing endpoint properties for Spring Boot 4
- add spring-boot-zipkin so Zipkin exporter has its sender auto-configuration
- assert TRACING_URL binding for both exporter profiles

## Verification
- rtk mvn -q clean test -Dtest=TracingOtlpExporterProfileTest,TracingZipkinExporterProfileTest