### PR TITLE
fix(mesh): restore realm fallback for Mesh LMS issuers

### DIFF
--- a/src/main/java/jumper/model/config/JumperConfig.java
+++ b/src/main/java/jumper/model/config/JumperConfig.java
@@ -132,10 +132,7 @@ public class JumperConfig {
               HeaderUtil.getLastValueFromHeaderField(
                   request, Constants.HEADER_ACCESS_TOKEN_FORWARDING)));
     }
-    setRealmName(HeaderUtil.getLastValueFromHeaderField(request, Constants.HEADER_REALM));
-    if (StringUtils.isBlank(getRealmName())) {
-      setRealmName(Constants.DEFAULT_REALM);
-    }
+    setRealmName(determineRealm(request));
     setEnvName(HeaderUtil.getLastValueFromHeaderField(request, Constants.HEADER_ENVIRONMENT));
 
     // external oauth
@@ -185,6 +182,7 @@ public class JumperConfig {
             HeaderUtil.getLastValueFromHeaderField(request, Constants.HEADER_JUMPER_CONFIG));
     this.setRouteListener(jc.getRouteListener());
     this.setGatewayClient(jc.getGatewayClient());
+    setRealmName(determineRealm(request));
 
     // check loadBalancing
     if (Objects.nonNull(loadBalancing) && !loadBalancing.getServers().isEmpty()) {
@@ -221,6 +219,25 @@ public class JumperConfig {
   public boolean isListenerMatched() {
     return Objects.nonNull(getRouteListener())
         && Objects.nonNull(getRouteListener().get(getConsumer()));
+  }
+
+  String determineRealm(ServerHttpRequest request) {
+    if (StringUtils.isNotBlank(getRealmName())) {
+      return getRealmName();
+    }
+
+    // TODO: remove legacy realm header and issuer fallbacks after Mesh LMS phase 2 completes.
+    String legacyRealmHeader =
+        HeaderUtil.getLastValueFromHeaderField(request, Constants.HEADER_REALM);
+    if (StringUtils.isNotBlank(legacyRealmHeader)) {
+      return legacyRealmHeader;
+    }
+
+    if (StringUtils.isNotBlank(getInternalTokenEndpoint())) {
+      return getInternalTokenEndpoint().replaceFirst(".*realms/", "");
+    }
+
+    return Constants.DEFAULT_REALM;
   }
 
   /**

--- a/src/test/java/jumper/HeaderSteps.java
+++ b/src/test/java/jumper/HeaderSteps.java
@@ -43,6 +43,27 @@ public class HeaderSteps {
     baseSteps.setHttpHeadersOfRequest(TokenUtil.getProxyRouteHeadersLegacyIssuer(baseSteps));
   }
 
+  @Given("ProxyRoute headers are set with jumper_config realm")
+  public void proxyRouteHeadersSetWithJumperConfigRealm() {
+    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
+    baseSteps.setHttpHeadersOfRequest(
+        TokenUtil.getProxyRouteHeadersWithJumperConfigRealm(baseSteps));
+  }
+
+  @Given("ProxyRoute headers are set with legacy realm header")
+  public void proxyRouteHeadersSetWithLegacyRealmHeader() {
+    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
+    baseSteps.setHttpHeadersOfRequest(
+        TokenUtil.getProxyRouteHeadersWithLegacyRealmHeader(baseSteps));
+  }
+
+  @Given("ProxyRoute headers are set with legacy issuer for non-default realm")
+  public void proxyRouteHeadersSetWithLegacyIssuerForNonDefaultRealm() {
+    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
+    baseSteps.setHttpHeadersOfRequest(
+        TokenUtil.getProxyRouteHeadersLegacyIssuerWithNonDefaultRealm(baseSteps));
+  }
+
   @Given("A header {word} is set with value {word}")
   public void tardisTraceIdSet(String headerName, String headerValue) {
     baseSteps.setHttpHeadersOfRequest(
@@ -107,6 +128,27 @@ public class HeaderSteps {
     baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
     baseSteps.setHttpHeadersOfRequest(
         RoutingConfigUtil.getProxyRouteHeadersLegacyIssuer(baseSteps));
+  }
+
+  @Given("Proxy routing_config header set with routing_config realm")
+  public void proxyRoutingConfigHeaderSetWithRoutingConfigRealm() {
+    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
+    baseSteps.setHttpHeadersOfRequest(
+        RoutingConfigUtil.getProxyRouteHeadersWithRoutingConfigRealm(baseSteps));
+  }
+
+  @Given("Proxy routing_config header set with legacy realm header")
+  public void proxyRoutingConfigHeaderSetWithLegacyRealmHeader() {
+    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
+    baseSteps.setHttpHeadersOfRequest(
+        RoutingConfigUtil.getProxyRouteHeadersWithLegacyRealmHeader(baseSteps));
+  }
+
+  @Given("Proxy routing_config header set with legacy issuer for non-default realm")
+  public void proxyRoutingConfigHeaderSetWithLegacyIssuerForNonDefaultRealm() {
+    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
+    baseSteps.setHttpHeadersOfRequest(
+        RoutingConfigUtil.getProxyRouteHeadersLegacyIssuerWithNonDefaultRealm(baseSteps));
   }
 
   @Given("RealRoute headers without Authorization are set")

--- a/src/test/java/jumper/VerificationSteps.java
+++ b/src/test/java/jumper/VerificationSteps.java
@@ -146,6 +146,13 @@ public class VerificationSteps {
           .value(HttpHeaders.AUTHORIZATION, this::checkMeshToken)
           .expectHeader()
           .doesNotExist(Constants.HEADER_CONSUMER_TOKEN);
+    } else if (tokenType.equalsIgnoreCase("MeshTokenWithNonDefaultRealm")) {
+      this.baseSteps
+          .getRequestExchange()
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkMeshTokenWithNonDefaultRealm)
+          .expectHeader()
+          .doesNotExist(Constants.HEADER_CONSUMER_TOKEN);
     } else if (tokenType.equalsIgnoreCase("ExternalConfigured")) {
       this.baseSteps
           .getRequestExchange()
@@ -263,6 +270,14 @@ public class VerificationSteps {
   }
 
   private void checkMeshToken(String meshLmsToken) {
+    checkMeshToken(meshLmsToken, Constants.DEFAULT_REALM);
+  }
+
+  private void checkMeshTokenWithNonDefaultRealm(String meshLmsToken) {
+    checkMeshToken(meshLmsToken, NON_DEFAULT_REALM);
+  }
+
+  private void checkMeshToken(String meshLmsToken, String expectedRealm) {
     Jwt<?, Claims> claimsFromToken = OauthTokenUtil.getAllClaimsFromToken(meshLmsToken);
 
     assertEquals("Bearer", claimsFromToken.getBody().get("typ", String.class));
@@ -279,8 +294,7 @@ public class VerificationSteps {
     assertEquals(ORIGIN_ZONE, claimsFromToken.getBody().get("originZone", String.class));
     assertEquals(ORIGIN_STARGATE, claimsFromToken.getBody().get("originStargate", String.class));
     // iss is the local StarGate issuer URL — the provider zone validates against its JWKS
-    assertEquals(
-        localIssuerUrl + "/" + Constants.DEFAULT_REALM, claimsFromToken.getBody().getIssuer());
+    assertEquals(localIssuerUrl + "/" + expectedRealm, claimsFromToken.getBody().getIssuer());
     assertNotNull(claimsFromToken.getBody().getExpiration());
     assertNotNull(claimsFromToken.getBody().getIssuedAt());
   }

--- a/src/test/java/jumper/config/Config.java
+++ b/src/test/java/jumper/config/Config.java
@@ -19,6 +19,7 @@ public class Config {
   public static final String ENVIRONMENT = "localEnv";
   public static final String ENVIRONMENT_REMOTE = "remoteEnv";
   public static final String REALM = "default";
+  public static final String NON_DEFAULT_REALM = "sit";
   public static final String BASE_PATH = "/eni/test/v1";
   public static final String LOCAL_ISSUER = "https://iris.local:1234/auth/realms/default";
   public static final String REMOTE_ISSUER = "https://iris.remote:1234/auth/realms/default";

--- a/src/test/java/jumper/model/config/JumperConfigTest.java
+++ b/src/test/java/jumper/model/config/JumperConfigTest.java
@@ -7,14 +7,19 @@ package jumper.model.config;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
+import jumper.Constants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 
 class JumperConfigTest {
 
   private static final String ISSUER = "http://localhost:1081/auth/realms/default";
+  private static final String NON_DEFAULT_REALM = "sit";
+  private static final String OTHER_REALM = "rv";
 
   static Stream<Arguments> isMeshRouteCases() {
     return Stream.of(
@@ -49,5 +54,72 @@ class JumperConfigTest {
 
     // act & assert
     assertEquals(false, jc.isMeshRoute());
+  }
+
+  @Test
+  void determineRealm_keepsJumperConfigRealm() {
+    // arrange
+    JumperConfig jc = new JumperConfig();
+    jc.setRealmName(NON_DEFAULT_REALM);
+    ServerHttpRequest request = requestWithRealmHeader(Constants.DEFAULT_REALM);
+
+    // act
+    String realm = jc.determineRealm(request);
+
+    // assert
+    assertEquals(NON_DEFAULT_REALM, realm);
+  }
+
+  @Test
+  void determineRealm_usesLegacyRealmHeaderWhenJumperConfigRealmIsMissing() {
+    // TODO: remove after mesh LMS phase 2 completes and the legacy realm header fallback is
+    // deleted.
+    // arrange
+    JumperConfig jc = new JumperConfig();
+    jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/" + OTHER_REALM);
+    ServerHttpRequest request = requestWithRealmHeader(NON_DEFAULT_REALM);
+
+    // act
+    String realm = jc.determineRealm(request);
+
+    // assert
+    assertEquals(NON_DEFAULT_REALM, realm);
+  }
+
+  @Test
+  void determineRealm_usesLegacyIssuerRealmWhenConfigAndHeaderRealmAreMissing() {
+    // TODO: remove after mesh LMS phase 2 completes and the legacy issuer realm fallback is
+    // deleted.
+    // arrange
+    JumperConfig jc = new JumperConfig();
+    jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/" + NON_DEFAULT_REALM);
+    ServerHttpRequest request = requestWithoutRealmHeader();
+
+    // act
+    String realm = jc.determineRealm(request);
+
+    // assert
+    assertEquals(NON_DEFAULT_REALM, realm);
+  }
+
+  @Test
+  void determineRealm_usesDefaultRealmWhenNoRealmSourceExists() {
+    // arrange
+    JumperConfig jc = new JumperConfig();
+    ServerHttpRequest request = requestWithoutRealmHeader();
+
+    // act
+    String realm = jc.determineRealm(request);
+
+    // assert
+    assertEquals(Constants.DEFAULT_REALM, realm);
+  }
+
+  private static ServerHttpRequest requestWithRealmHeader(String realm) {
+    return MockServerHttpRequest.get("/").header(Constants.HEADER_REALM, realm).build();
+  }
+
+  private static ServerHttpRequest requestWithoutRealmHeader() {
+    return MockServerHttpRequest.get("/").build();
   }
 }

--- a/src/test/java/jumper/util/JumperConfigUtil.java
+++ b/src/test/java/jumper/util/JumperConfigUtil.java
@@ -32,6 +32,13 @@ public class JumperConfigUtil {
     return toJsonBase64(jc);
   }
 
+  public static String getJcMeshWithRealm(String realm) {
+    JumperConfig jc = new JumperConfig();
+    jc.setMesh(true);
+    jc.setRealmName(realm);
+    return toJsonBase64(jc);
+  }
+
   public static String getJcBasicAuthConsumer(String id) {
     HashMap<String, BasicAuthCredentials> basicAuthCredentialsHashMap = new HashMap<>();
     BasicAuthCredentials ba = new BasicAuthCredentials();

--- a/src/test/java/jumper/util/RoutingConfigUtil.java
+++ b/src/test/java/jumper/util/RoutingConfigUtil.java
@@ -41,10 +41,40 @@ public class RoutingConfigUtil {
     };
   }
 
+  public static Consumer<HttpHeaders> getProxyRouteHeadersWithRoutingConfigRealm(
+      BaseSteps baseSteps) {
+    return httpHeaders -> {
+      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
+      httpHeaders.set(Constants.HEADER_ROUTING_CONFIG, getRcProxyWithRoutingConfigRealm());
+      httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, JumperConfigUtil.getJcMesh());
+    };
+  }
+
+  public static Consumer<HttpHeaders> getProxyRouteHeadersWithLegacyRealmHeader(
+      BaseSteps baseSteps) {
+    return httpHeaders -> {
+      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
+      httpHeaders.set(Constants.HEADER_REALM, NON_DEFAULT_REALM);
+      httpHeaders.set(Constants.HEADER_ROUTING_CONFIG, getRcProxy());
+      httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, JumperConfigUtil.getJcMesh());
+    };
+  }
+
   public static Consumer<HttpHeaders> getProxyRouteHeadersLegacyIssuer(BaseSteps baseSteps) {
     return httpHeaders -> {
       httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
       httpHeaders.set(Constants.HEADER_ROUTING_CONFIG, getRcProxyLegacyIssuer(baseSteps.getId()));
+      httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, "e30=");
+    };
+  }
+
+  public static Consumer<HttpHeaders> getProxyRouteHeadersLegacyIssuerWithNonDefaultRealm(
+      BaseSteps baseSteps) {
+    return httpHeaders -> {
+      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
+      httpHeaders.set(
+          Constants.HEADER_ROUTING_CONFIG,
+          getRcProxyLegacyIssuerWithNonDefaultRealm(baseSteps.getId()));
       httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, "e30=");
     };
   }
@@ -65,12 +95,28 @@ public class RoutingConfigUtil {
         List.of(getProxyRouteJc(REMOTE_ZONE_NAME), getProxyRouteJc(REMOTE_FAILOVER_ZONE_NAME)));
   }
 
+  public static String getRcProxyWithRoutingConfigRealm() {
+    // proxy + proxy, selected entry realm wins over legacy header and issuer fallbacks
+    return toJsonBase64(
+        List.of(
+            getProxyRouteJcWithRoutingConfigRealm(REMOTE_ZONE_NAME),
+            getProxyRouteJc(REMOTE_FAILOVER_ZONE_NAME)));
+  }
+
   public static String getRcProxyLegacyIssuer(String id) {
     // proxy + proxy, using the legacy issuer trigger as transitional fallback
     return toJsonBase64(
         List.of(
             getProxyRouteJcLegacyIssuer(REMOTE_ZONE_NAME, id),
             getProxyRouteJcLegacyIssuer(REMOTE_FAILOVER_ZONE_NAME, id)));
+  }
+
+  public static String getRcProxyLegacyIssuerWithNonDefaultRealm(String id) {
+    // proxy + proxy, using the legacy issuer trigger and realm fallback as transitional fallback
+    return toJsonBase64(
+        List.of(
+            getProxyRouteJcLegacyIssuerWithNonDefaultRealm(REMOTE_ZONE_NAME, id),
+            getProxyRouteJcLegacyIssuerWithNonDefaultRealm(REMOTE_FAILOVER_ZONE_NAME, id)));
   }
 
   private static JumperConfig getProxyRouteJc(String targetZone) {
@@ -81,9 +127,26 @@ public class RoutingConfigUtil {
     return jc;
   }
 
+  private static JumperConfig getProxyRouteJcWithRoutingConfigRealm(String targetZone) {
+    JumperConfig jc = getProxyRouteJc(targetZone);
+    jc.setRealmName(NON_DEFAULT_REALM);
+    return jc;
+  }
+
   private static JumperConfig getProxyRouteJcLegacyIssuer(String targetZone, String id) {
     JumperConfig jc = new JumperConfig();
     jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/default");
+    jc.setClientId(addIdSuffix("stargate", id));
+    jc.setClientSecret("secret");
+
+    setProxyRouteTarget(jc, targetZone);
+    return jc;
+  }
+
+  private static JumperConfig getProxyRouteJcLegacyIssuerWithNonDefaultRealm(
+      String targetZone, String id) {
+    JumperConfig jc = new JumperConfig();
+    jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/" + NON_DEFAULT_REALM);
     jc.setClientId(addIdSuffix("stargate", id));
     jc.setClientSecret("secret");
 

--- a/src/test/java/jumper/util/TokenUtil.java
+++ b/src/test/java/jumper/util/TokenUtil.java
@@ -68,6 +68,26 @@ public class TokenUtil {
     };
   }
 
+  public static Consumer<HttpHeaders> getProxyRouteHeadersWithJumperConfigRealm(
+      BaseSteps baseSteps) {
+    return httpHeaders -> {
+      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
+      httpHeaders.set(Constants.HEADER_REMOTE_API_URL, "http://localhost:1080");
+      httpHeaders.set(
+          Constants.HEADER_JUMPER_CONFIG, JumperConfigUtil.getJcMeshWithRealm(NON_DEFAULT_REALM));
+    };
+  }
+
+  public static Consumer<HttpHeaders> getProxyRouteHeadersWithLegacyRealmHeader(
+      BaseSteps baseSteps) {
+    return httpHeaders -> {
+      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
+      httpHeaders.set(Constants.HEADER_REMOTE_API_URL, "http://localhost:1080");
+      httpHeaders.set(Constants.HEADER_REALM, NON_DEFAULT_REALM);
+      httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, JumperConfigUtil.getJcMesh());
+    };
+  }
+
   public static Consumer<HttpHeaders> getProxyRouteHeadersWithXtokenExchange(BaseSteps baseSteps) {
     return httpHeaders -> {
       httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
@@ -82,6 +102,19 @@ public class TokenUtil {
       httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
       httpHeaders.set(Constants.HEADER_REMOTE_API_URL, "http://localhost:1080");
       httpHeaders.set(Constants.HEADER_ISSUER, "http://localhost:1081/auth/realms/default");
+      httpHeaders.set(Constants.HEADER_CLIENT_ID, addIdSuffix("stargate", baseSteps.getId()));
+      httpHeaders.set(Constants.HEADER_CLIENT_SECRET, "secret");
+      httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, "e30=");
+    };
+  }
+
+  public static Consumer<HttpHeaders> getProxyRouteHeadersLegacyIssuerWithNonDefaultRealm(
+      BaseSteps baseSteps) {
+    return httpHeaders -> {
+      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
+      httpHeaders.set(Constants.HEADER_REMOTE_API_URL, "http://localhost:1080");
+      httpHeaders.set(
+          Constants.HEADER_ISSUER, "http://localhost:1081/auth/realms/" + NON_DEFAULT_REALM);
       httpHeaders.set(Constants.HEADER_CLIENT_ID, addIdSuffix("stargate", baseSteps.getId()));
       httpHeaders.set(Constants.HEADER_CLIENT_SECRET, "secret");
       httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, "e30=");

--- a/src/test/resources/features/authorizationHeader.feature
+++ b/src/test/resources/features/authorizationHeader.feature
@@ -94,6 +94,32 @@ Feature: proper authorization token reaches provider endpoint
     And API consumer receives a 200 status code
     And API Provider receives header x-tardis-traceid that matches regex dummy
 
+  Scenario: Consumer calls proxy route with non-default realm in jumper_config, mesh LMS token issuer uses realm
+    Given ProxyRoute headers are set with jumper_config realm
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives default bearer authorization headers
+    Then API Provider receives authorization MeshTokenWithNonDefaultRealm
+    And API consumer receives a 200 status code
+
+  # TODO: remove after CP phase 2 completes and the legacy realm header fallback is deleted.
+  Scenario: Consumer calls proxy route with legacy non-default realm header, mesh LMS token issuer uses realm
+    Given ProxyRoute headers are set with legacy realm header
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives default bearer authorization headers
+    Then API Provider receives authorization MeshTokenWithNonDefaultRealm
+    And API consumer receives a 200 status code
+
+  # TODO: remove after CP phase 2 completes and the legacy issuer realm fallback is deleted.
+  Scenario: Consumer calls proxy route with legacy issuer header for non-default realm, mesh LMS token issuer uses realm
+    Given ProxyRoute headers are set with legacy issuer for non-default realm
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives default bearer authorization headers
+    Then API Provider receives authorization MeshTokenWithNonDefaultRealm
+    And API consumer receives a 200 status code
+
   ################ external legacy ################
   Scenario: Consumer calls proxy route with jc with oauth, external authorization token sent
     Given RealRoute headers are set

--- a/src/test/resources/features/failover.feature
+++ b/src/test/resources/features/failover.feature
@@ -60,6 +60,29 @@ Feature: request containing routing_config properly handled
     Then API Provider receives default bearer authorization headers
     Then API Provider receives authorization MeshToken
 
+  Scenario: Consumer calls proxy route with realm in routing_config, mesh LMS token issuer uses realm
+    Given Proxy routing_config header set with routing_config realm
+    And API provider set to respond on real path
+    When consumer calls the proxy route without base path
+    Then API Provider receives default bearer authorization headers
+    Then API Provider receives authorization MeshTokenWithNonDefaultRealm
+
+  # TODO: remove after CP phase 2 completes and the legacy realm header fallback is deleted.
+  Scenario: Consumer calls proxy route with legacy non-default realm header, mesh LMS token issuer uses realm
+    Given Proxy routing_config header set with legacy realm header
+    And API provider set to respond on real path
+    When consumer calls the proxy route without base path
+    Then API Provider receives default bearer authorization headers
+    Then API Provider receives authorization MeshTokenWithNonDefaultRealm
+
+  # TODO: remove after CP phase 2 completes and the legacy issuer realm fallback is deleted.
+  Scenario: Consumer calls proxy route with legacy issuer header for non-default realm, mesh LMS token issuer uses realm
+    Given Proxy routing_config header set with legacy issuer for non-default realm
+    And API provider set to respond on real path
+    When consumer calls the proxy route without base path
+    Then API Provider receives default bearer authorization headers
+    Then API Provider receives authorization MeshTokenWithNonDefaultRealm
+
 ################ headers ################
   Scenario: Consumer calls proxy route with secondary config, check header stripped
     Given Secondary routing_config header set


### PR DESCRIPTION
## Summary

Fix Mesh LMS token issuer generation for non-default realms.

Jumper now resolves the realm in the migration-safe priority order:

1. `realm` from `jumper_config` / selected `routing_config`
2. legacy `realm` header
3. legacy `issuer` realm fallback
4. `default`

This prevents customer-facing mesh calls in non-default realms such as `sit` from producing Mesh LMS tokens with the wrong issuer (`.../default`), which caused provider-zone 401s when `allowed_iss` expected the non-default realm issuer, while simultaneously preparing for the post-phase-2 control-plane shape where `realm` will be set in `jumper_config` / `routing_config`.

## Changes

- Preserve `realm` from decoded `jumper_config` and selected `routing_config` entries.
- Add `determineRealm()` in `JumperConfig` for the config-first fallback chain.
- Apply the same realm resolution in normal and `routing_config` paths.
- Add Cucumber coverage for:
  - `jumper_config` realm
  - `routing_config` realm
  - legacy realm header fallback
  - legacy issuer fallback
- Add unit coverage for realm resolution priority.
- Mark legacy header and issuer fallback tests for removal after Mesh LMS phase 2.

## Verification

- `./mvnw spotless:apply`
- `./mvnw clean test -Dtest=JumperConfigTest`
- `./mvnw clean test -Dtest=RunCucumberTest`
- `./mvnw clean test`

Note: Spotless was not rerun after the final review-only naming changes per request.