### PR TITLE
fix(mesh): use realm header as canonical source

### DIFF
--- a/src/main/java/jumper/Constants.java
+++ b/src/main/java/jumper/Constants.java
@@ -48,7 +48,9 @@ public class Constants {
   public static final String HEADER_X_SPACEGATE_TOKEN = "X-Spacegate-Token";
   public static final String HEADER_X_TOKEN_EXCHANGE = "X-Token-Exchange";
   public static final String HEADER_API_BASE_PATH = "api_base_path";
+  public static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
   public static final String HEADER_X_FORWARDED_HOST = "X-Forwarded-Host";
+  public static final String HEADER_X_FORWARDED_PATH = "X-Forwarded-Path";
   public static final String HEADER_X_FORWARDED_PORT = "X-Forwarded-Port";
   public static final String HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto";
   public static final String HEADER_X_FORWARDED_PORT_PORT = "443";

--- a/src/main/java/jumper/model/config/JumperConfig.java
+++ b/src/main/java/jumper/model/config/JumperConfig.java
@@ -222,17 +222,12 @@ public class JumperConfig {
   }
 
   String determineRealm(ServerHttpRequest request) {
-    if (StringUtils.isNotBlank(getRealmName())) {
-      return getRealmName();
+    String realmHeader = HeaderUtil.getLastValueFromHeaderField(request, Constants.HEADER_REALM);
+    if (StringUtils.isNotBlank(realmHeader)) {
+      return realmHeader;
     }
 
-    // TODO: remove legacy realm header and issuer fallbacks after Mesh LMS phase 2 completes.
-    String legacyRealmHeader =
-        HeaderUtil.getLastValueFromHeaderField(request, Constants.HEADER_REALM);
-    if (StringUtils.isNotBlank(legacyRealmHeader)) {
-      return legacyRealmHeader;
-    }
-
+    // TODO: remove the legacy issuer fallback after the control-plane migration completes.
     if (StringUtils.isNotBlank(getInternalTokenEndpoint())) {
       return getInternalTokenEndpoint().replaceFirst(".*realms/", "");
     }

--- a/src/test/java/jumper/HeaderSteps.java
+++ b/src/test/java/jumper/HeaderSteps.java
@@ -210,6 +210,17 @@ public class HeaderSteps {
             }));
   }
 
+  @And("documented consumer headers are set")
+  public void addDocumentedConsumerHeaders() {
+    baseSteps.setHttpHeadersOfRequest(
+        baseSteps.httpHeadersOfRequest.andThen(
+            httpHeaders -> {
+              httpHeaders.set(Constants.HEADER_X_FORWARDED_FOR, FORWARDED_FOR);
+              httpHeaders.set(Constants.HEADER_X_FORWARDED_PATH, FORWARDED_PATH);
+              httpHeaders.set(CUSTOM_CONSUMER_HEADER, CUSTOM_CONSUMER_HEADER_VALUE);
+            }));
+  }
+
   @And("skip zone header set")
   public void setSkipZoneHeader() {
     baseSteps.setHttpHeadersOfRequest(

--- a/src/test/java/jumper/HeaderSteps.java
+++ b/src/test/java/jumper/HeaderSteps.java
@@ -43,18 +43,10 @@ public class HeaderSteps {
     baseSteps.setHttpHeadersOfRequest(TokenUtil.getProxyRouteHeadersLegacyIssuer(baseSteps));
   }
 
-  @Given("ProxyRoute headers are set with jumper_config realm")
-  public void proxyRouteHeadersSetWithJumperConfigRealm() {
+  @Given("ProxyRoute headers are set with realm header")
+  public void proxyRouteHeadersSetWithRealmHeader() {
     baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
-    baseSteps.setHttpHeadersOfRequest(
-        TokenUtil.getProxyRouteHeadersWithJumperConfigRealm(baseSteps));
-  }
-
-  @Given("ProxyRoute headers are set with legacy realm header")
-  public void proxyRouteHeadersSetWithLegacyRealmHeader() {
-    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
-    baseSteps.setHttpHeadersOfRequest(
-        TokenUtil.getProxyRouteHeadersWithLegacyRealmHeader(baseSteps));
+    baseSteps.setHttpHeadersOfRequest(TokenUtil.getProxyRouteHeadersWithRealmHeader(baseSteps));
   }
 
   @Given("ProxyRoute headers are set with legacy issuer for non-default realm")
@@ -130,18 +122,11 @@ public class HeaderSteps {
         RoutingConfigUtil.getProxyRouteHeadersLegacyIssuer(baseSteps));
   }
 
-  @Given("Proxy routing_config header set with routing_config realm")
-  public void proxyRoutingConfigHeaderSetWithRoutingConfigRealm() {
+  @Given("Proxy routing_config header set with realm header")
+  public void proxyRoutingConfigHeaderSetWithRealmHeader() {
     baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
     baseSteps.setHttpHeadersOfRequest(
-        RoutingConfigUtil.getProxyRouteHeadersWithRoutingConfigRealm(baseSteps));
-  }
-
-  @Given("Proxy routing_config header set with legacy realm header")
-  public void proxyRoutingConfigHeaderSetWithLegacyRealmHeader() {
-    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
-    baseSteps.setHttpHeadersOfRequest(
-        RoutingConfigUtil.getProxyRouteHeadersWithLegacyRealmHeader(baseSteps));
+        RoutingConfigUtil.getProxyRouteHeadersWithRealmHeader(baseSteps));
   }
 
   @Given("Proxy routing_config header set with legacy issuer for non-default realm")

--- a/src/test/java/jumper/VerificationSteps.java
+++ b/src/test/java/jumper/VerificationSteps.java
@@ -94,6 +94,34 @@ public class VerificationSteps {
     this.baseSteps.getRequestExchange().expectHeader().doesNotExist("routing_config");
   }
 
+  @Then("API Provider receives documented standard and consumer headers")
+  public void apiProviderReceivesDocumentedHeaders() {
+    this.baseSteps
+        .getRequestExchange()
+        .expectHeader()
+        .valueMatches(Constants.HEADER_X_B3_TRACE_ID, "\\w+")
+        .expectHeader()
+        .valueMatches(Constants.HEADER_X_B3_SPAN_ID, "\\w+")
+        .expectHeader()
+        .valueEquals(Constants.HEADER_X_B3_SAMPLED, "1")
+        .expectHeader()
+        .valueEquals(Constants.HEADER_X_FORWARDED_HOST, "zone.local.de")
+        .expectHeader()
+        .valueEquals(Constants.HEADER_X_FORWARDED_PORT, Constants.HEADER_X_FORWARDED_PORT_PORT)
+        .expectHeader()
+        .valueEquals(Constants.HEADER_X_FORWARDED_PROTO, Constants.HEADER_X_FORWARDED_PROTO_HTTPS)
+        .expectHeader()
+        .valueEquals(Constants.HEADER_X_FORWARDED_FOR, FORWARDED_FOR)
+        .expectHeader()
+        .valueEquals(Constants.HEADER_X_FORWARDED_PATH, FORWARDED_PATH)
+        .expectHeader()
+        .valueEquals(Constants.HEADER_REALM, REALM)
+        .expectHeader()
+        .valueEquals(Constants.HEADER_ENVIRONMENT, ENVIRONMENT)
+        .expectHeader()
+        .valueEquals(CUSTOM_CONSUMER_HEADER, CUSTOM_CONSUMER_HEADER_VALUE);
+  }
+
   @Then("API Provider receives no authorization header")
   public void apiProvidersReceivesNoAuthorizationHeader() {
     this.baseSteps.getRequestExchange().expectHeader().doesNotExist("Authorization");

--- a/src/test/java/jumper/config/Config.java
+++ b/src/test/java/jumper/config/Config.java
@@ -28,6 +28,10 @@ public class Config {
   public static final String PUBSUB_SUBSCRIBER = "testSubscriber";
   public static final String LISTENER_ISSUE = "issue";
   public static final String LISTENER_PROVIDER = "serviceOwner";
+  public static final String FORWARDED_FOR = "192.0.2.1";
+  public static final String FORWARDED_PATH = "/documented/path";
+  public static final String CUSTOM_CONSUMER_HEADER = "X-Custom-Consumer-Header";
+  public static final String CUSTOM_CONSUMER_HEADER_VALUE = "custom-value";
   public static final int REMOTE_HOST_PORT = 1080;
   public static final String REMOTE_BASE_PATH = "/real";
   public static final String REMOTE_FAILOVER_BASE_PATH = "/failover";

--- a/src/test/java/jumper/model/config/JumperConfigTest.java
+++ b/src/test/java/jumper/model/config/JumperConfigTest.java
@@ -57,41 +57,23 @@ class JumperConfigTest {
   }
 
   @Test
-  void determineRealm_keepsJumperConfigRealm() {
+  void determineRealm_usesRealmHeader() {
     // arrange
     JumperConfig jc = new JumperConfig();
-    jc.setRealmName(NON_DEFAULT_REALM);
     ServerHttpRequest request = requestWithRealmHeader(Constants.DEFAULT_REALM);
 
     // act
     String realm = jc.determineRealm(request);
 
     // assert
-    assertEquals(NON_DEFAULT_REALM, realm);
+    assertEquals(Constants.DEFAULT_REALM, realm);
   }
 
   @Test
-  void determineRealm_usesLegacyRealmHeaderWhenJumperConfigRealmIsMissing() {
-    // TODO: remove after mesh LMS phase 2 completes and the legacy realm header fallback is
-    // deleted.
+  void determineRealm_usesLegacyIssuerRealmWhenHeaderIsMissing() {
     // arrange
     JumperConfig jc = new JumperConfig();
-    jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/" + OTHER_REALM);
-    ServerHttpRequest request = requestWithRealmHeader(NON_DEFAULT_REALM);
-
-    // act
-    String realm = jc.determineRealm(request);
-
-    // assert
-    assertEquals(NON_DEFAULT_REALM, realm);
-  }
-
-  @Test
-  void determineRealm_usesLegacyIssuerRealmWhenConfigAndHeaderRealmAreMissing() {
-    // TODO: remove after mesh LMS phase 2 completes and the legacy issuer realm fallback is
-    // deleted.
-    // arrange
-    JumperConfig jc = new JumperConfig();
+    jc.setRealmName(OTHER_REALM);
     jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/" + NON_DEFAULT_REALM);
     ServerHttpRequest request = requestWithoutRealmHeader();
 
@@ -106,6 +88,7 @@ class JumperConfigTest {
   void determineRealm_usesDefaultRealmWhenNoRealmSourceExists() {
     // arrange
     JumperConfig jc = new JumperConfig();
+    jc.setRealmName(NON_DEFAULT_REALM);
     ServerHttpRequest request = requestWithoutRealmHeader();
 
     // act

--- a/src/test/java/jumper/util/JumperConfigUtil.java
+++ b/src/test/java/jumper/util/JumperConfigUtil.java
@@ -32,13 +32,6 @@ public class JumperConfigUtil {
     return toJsonBase64(jc);
   }
 
-  public static String getJcMeshWithRealm(String realm) {
-    JumperConfig jc = new JumperConfig();
-    jc.setMesh(true);
-    jc.setRealmName(realm);
-    return toJsonBase64(jc);
-  }
-
   public static String getJcBasicAuthConsumer(String id) {
     HashMap<String, BasicAuthCredentials> basicAuthCredentialsHashMap = new HashMap<>();
     BasicAuthCredentials ba = new BasicAuthCredentials();

--- a/src/test/java/jumper/util/RoutingConfigUtil.java
+++ b/src/test/java/jumper/util/RoutingConfigUtil.java
@@ -41,17 +41,7 @@ public class RoutingConfigUtil {
     };
   }
 
-  public static Consumer<HttpHeaders> getProxyRouteHeadersWithRoutingConfigRealm(
-      BaseSteps baseSteps) {
-    return httpHeaders -> {
-      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
-      httpHeaders.set(Constants.HEADER_ROUTING_CONFIG, getRcProxyWithRoutingConfigRealm());
-      httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, JumperConfigUtil.getJcMesh());
-    };
-  }
-
-  public static Consumer<HttpHeaders> getProxyRouteHeadersWithLegacyRealmHeader(
-      BaseSteps baseSteps) {
+  public static Consumer<HttpHeaders> getProxyRouteHeadersWithRealmHeader(BaseSteps baseSteps) {
     return httpHeaders -> {
       httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
       httpHeaders.set(Constants.HEADER_REALM, NON_DEFAULT_REALM);
@@ -95,14 +85,6 @@ public class RoutingConfigUtil {
         List.of(getProxyRouteJc(REMOTE_ZONE_NAME), getProxyRouteJc(REMOTE_FAILOVER_ZONE_NAME)));
   }
 
-  public static String getRcProxyWithRoutingConfigRealm() {
-    // proxy + proxy, selected entry realm wins over legacy header and issuer fallbacks
-    return toJsonBase64(
-        List.of(
-            getProxyRouteJcWithRoutingConfigRealm(REMOTE_ZONE_NAME),
-            getProxyRouteJc(REMOTE_FAILOVER_ZONE_NAME)));
-  }
-
   public static String getRcProxyLegacyIssuer(String id) {
     // proxy + proxy, using the legacy issuer trigger as transitional fallback
     return toJsonBase64(
@@ -124,12 +106,6 @@ public class RoutingConfigUtil {
     jc.setMesh(true);
 
     setProxyRouteTarget(jc, targetZone);
-    return jc;
-  }
-
-  private static JumperConfig getProxyRouteJcWithRoutingConfigRealm(String targetZone) {
-    JumperConfig jc = getProxyRouteJc(targetZone);
-    jc.setRealmName(NON_DEFAULT_REALM);
     return jc;
   }
 

--- a/src/test/java/jumper/util/TokenUtil.java
+++ b/src/test/java/jumper/util/TokenUtil.java
@@ -68,18 +68,7 @@ public class TokenUtil {
     };
   }
 
-  public static Consumer<HttpHeaders> getProxyRouteHeadersWithJumperConfigRealm(
-      BaseSteps baseSteps) {
-    return httpHeaders -> {
-      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
-      httpHeaders.set(Constants.HEADER_REMOTE_API_URL, "http://localhost:1080");
-      httpHeaders.set(
-          Constants.HEADER_JUMPER_CONFIG, JumperConfigUtil.getJcMeshWithRealm(NON_DEFAULT_REALM));
-    };
-  }
-
-  public static Consumer<HttpHeaders> getProxyRouteHeadersWithLegacyRealmHeader(
-      BaseSteps baseSteps) {
+  public static Consumer<HttpHeaders> getProxyRouteHeadersWithRealmHeader(BaseSteps baseSteps) {
     return httpHeaders -> {
       httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
       httpHeaders.set(Constants.HEADER_REMOTE_API_URL, "http://localhost:1080");

--- a/src/test/resources/features/authorizationHeader.feature
+++ b/src/test/resources/features/authorizationHeader.feature
@@ -94,17 +94,8 @@ Feature: proper authorization token reaches provider endpoint
     And API consumer receives a 200 status code
     And API Provider receives header x-tardis-traceid that matches regex dummy
 
-  Scenario: Consumer calls proxy route with non-default realm in jumper_config, mesh LMS token issuer uses realm
-    Given ProxyRoute headers are set with jumper_config realm
-    And API provider set to respond with a 200 status code
-    When consumer calls the proxy route
-    Then API Provider receives default bearer authorization headers
-    Then API Provider receives authorization MeshTokenWithNonDefaultRealm
-    And API consumer receives a 200 status code
-
-  # TODO: remove after CP phase 2 completes and the legacy realm header fallback is deleted.
-  Scenario: Consumer calls proxy route with legacy non-default realm header, mesh LMS token issuer uses realm
-    Given ProxyRoute headers are set with legacy realm header
+  Scenario: Consumer calls proxy route with non-default realm header, mesh LMS token issuer uses realm
+    Given ProxyRoute headers are set with realm header
     And API provider set to respond with a 200 status code
     When consumer calls the proxy route
     Then API Provider receives default bearer authorization headers

--- a/src/test/resources/features/failover.feature
+++ b/src/test/resources/features/failover.feature
@@ -60,16 +60,8 @@ Feature: request containing routing_config properly handled
     Then API Provider receives default bearer authorization headers
     Then API Provider receives authorization MeshToken
 
-  Scenario: Consumer calls proxy route with realm in routing_config, mesh LMS token issuer uses realm
-    Given Proxy routing_config header set with routing_config realm
-    And API provider set to respond on real path
-    When consumer calls the proxy route without base path
-    Then API Provider receives default bearer authorization headers
-    Then API Provider receives authorization MeshTokenWithNonDefaultRealm
-
-  # TODO: remove after CP phase 2 completes and the legacy realm header fallback is deleted.
-  Scenario: Consumer calls proxy route with legacy non-default realm header, mesh LMS token issuer uses realm
-    Given Proxy routing_config header set with legacy realm header
+  Scenario: Consumer calls proxy route with non-default realm header, mesh LMS token issuer uses realm
+    Given Proxy routing_config header set with realm header
     And API provider set to respond on real path
     When consumer calls the proxy route without base path
     Then API Provider receives default bearer authorization headers

--- a/src/test/resources/features/upstreamContent.feature
+++ b/src/test/resources/features/upstreamContent.feature
@@ -5,6 +5,14 @@
 @upstream @iris
 Feature: expected request content reaches provider upstream
 
+  Scenario: Documented standard and consumer headers reach provider
+    Given RealRoute headers are set
+    And documented consumer headers are set
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives documented standard and consumer headers
+    And API consumer receives a 200 status code
+
   Scenario: Consumer (technical) headers are removed for provider
     Given RealRoute headers are set
     And technical headers added


### PR DESCRIPTION
## Summary

Make the propagated `realm` header the canonical source for realm resolution.

This preserves the documented contract that `realm` is forwarded to upstream providers and avoids introducing a duplicate realm value in `jumper_config` or `routing_config`.

## Intent

The previous resolution order preferred realm values embedded in Jumper configuration. Since the `realm` header is a [documented standard gateway header](https://docs.devops.telekom.de/docs/developer-tools/tardis/components/stargate#standard-headers-set-by-stargate) and must remain available to upstream providers, embedding the same value in configuration provides no meaningful header-size benefit and risks inconsistent values.

Realm resolution now uses:

1. `realm` header
2. Legacy issuer-derived realm fallback
3. `default`

## Commits

### `4b9f684 fix(mesh): use realm header as canonical source`

- Prioritizes the propagated `realm` header.
- Removes realm resolution from `jumper_config` and `routing_config`.
- Retains the legacy issuer and default fallbacks.
- Updates unit and Mesh LMS integration coverage.

### `00c89c5 test(headers): cover documented propagation`

- Verifies documented `X-B3-*`, `X-Forwarded-*`, `Realm`, and `Environment` headers reach providers.
- Verifies consumer-defined headers are passed through unchanged.

## Verification

- `./mvnw clean test -Dtest=JumperConfigTest`
- `./mvnw clean test -Dtest=RunCucumberTest`
- 145 Cucumber scenarios passing.
