### PR TITLE
ci: build multi-arch container image for amd64 and arm64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,6 +377,16 @@ SPDX-License-Identifier: Apache-2.0
         <configuration>
           <from>
             <image>${jib.base-image}</image>
+            <platforms>
+              <platform>
+                <architecture>amd64</architecture>
+                <os>linux</os>
+              </platform>
+              <platform>
+                <architecture>arm64</architecture>
+                <os>linux</os>
+              </platform>
+            </platforms>
           </from>
           <to>
             <image>jumper</image>


### PR DESCRIPTION
Add linux/arm64 alongside linux/amd64 to the Jib build so the build-push-image job publishes a multi-arch