### PR TITLE
feat(token): support configured provider audiences

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,30 @@ The most common scenario where Jumper creates a new OAuth token by combining inf
 **Outgoing Headers:**
 * `Authorization` - Contains the newly created token
 
+##### Audience claim
+
+Providers can configure one audience for the provider-facing token through `jumper_config`:
+
+```json
+{
+  "claims": {
+    "default": [
+      { "key": "aud", "value": "checkout-api" }
+    ]
+  }
+}
+```
+
+The audience can be a literal `value` or use `valueFrom: "ConsumerClientId"`, which resolves to
+the incoming token's `clientId`. Exactly one of `value` or `valueFrom` must be set. Invalid `aud`
+configuration fails provider-token generation with an HTTP 500 response.
+
+Provider-token audience precedence is:
+
+1. The configured provider audience.
+2. Audience values from the incoming token.
+3. The `x-pubsub-subscriber-id` fallback for pub/sub calls.
+
 #### Last Mile Security Token (Legacy)
 
 A legacy scenario where Jumper forwards both the original token and a new LMS token (in an `X-Gateway-Token` header).

--- a/src/main/java/jumper/Constants.java
+++ b/src/main/java/jumper/Constants.java
@@ -108,6 +108,8 @@ public class Constants {
 
   public static final String BASIC_AUTH_PROVIDER_KEY = "default";
   public static final String OAUTH_PROVIDER_KEY = "default";
+  public static final String CLAIMS_DEFAULT_KEY = "default";
+  public static final String CLAIM_VALUE_FROM_CONSUMER_CLIENT_ID = "ConsumerClientId";
 
   public static final String ENVIRONMENT_PLACEHOLDER = "ENVIRONMENT_PLACEHOLDER";
 }

--- a/src/main/java/jumper/model/config/JumperConfig.java
+++ b/src/main/java/jumper/model/config/JumperConfig.java
@@ -266,10 +266,21 @@ public class JumperConfig {
       return Optional.empty();
     }
 
-    return defaultClaims.stream()
-        .filter(Objects::nonNull)
-        .filter(claim -> Constants.TOKEN_CLAIM_AUD.equals(claim.getKey()))
-        .findFirst();
+    List<ConfiguredClaim> audienceClaims =
+        defaultClaims.stream()
+            .filter(Objects::nonNull)
+            .filter(claim -> Constants.TOKEN_CLAIM_AUD.equals(claim.getKey()))
+            .toList();
+
+    // The control plane schema allows a single aud claim, so additional entries indicate config
+    // drift. The first entry still wins, so warn instead of failing an otherwise valid request.
+    if (audienceClaims.size() > 1) {
+      log.warn(
+          "Configured claims contain {} aud entries, only the first one is applied",
+          audienceClaims.size());
+    }
+
+    return audienceClaims.stream().findFirst();
   }
 
   @Data

--- a/src/main/java/jumper/model/config/JumperConfig.java
+++ b/src/main/java/jumper/model/config/JumperConfig.java
@@ -4,6 +4,7 @@
 
 package jumper.model.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jsonwebtoken.Claims;
@@ -28,6 +29,7 @@ public class JumperConfig {
 
   private HashMap<String, OauthCredentials> oauth;
   private HashMap<String, BasicAuthCredentials> basicAuth;
+  private HashMap<String, List<ConfiguredClaim>> claims;
   private HashMap<String, RouteListener> routeListener;
   private List<String> removeHeaders;
   private GatewayClient gatewayClient;
@@ -251,5 +253,30 @@ public class JumperConfig {
   public String getSecurityScopes() {
     Optional<OauthCredentials> oauthCredentials = getOauthCredentials();
     return oauthCredentials.map(OauthCredentials::getScopes).orElse(null);
+  }
+
+  @JsonIgnore
+  public Optional<ConfiguredClaim> getConfiguredAudienceClaim() {
+    if (Objects.isNull(claims)) {
+      return Optional.empty();
+    }
+
+    List<ConfiguredClaim> defaultClaims = claims.get(Constants.CLAIMS_DEFAULT_KEY);
+    if (Objects.isNull(defaultClaims)) {
+      return Optional.empty();
+    }
+
+    return defaultClaims.stream()
+        .filter(Objects::nonNull)
+        .filter(claim -> Constants.TOKEN_CLAIM_AUD.equals(claim.getKey()))
+        .findFirst();
+  }
+
+  @Data
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class ConfiguredClaim {
+    private String key;
+    private String value;
+    private String valueFrom;
   }
 }

--- a/src/main/java/jumper/service/TokenGeneratorService.java
+++ b/src/main/java/jumper/service/TokenGeneratorService.java
@@ -10,11 +10,13 @@ import java.security.interfaces.RSAKey;
 import java.util.*;
 import jumper.Constants;
 import jumper.model.config.JumperConfig;
+import jumper.model.config.JumperConfig.ConfiguredClaim;
 import jumper.model.config.KeyInfo;
 import jumper.util.OauthTokenUtil;
 import jumper.util.RsaUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -87,6 +89,8 @@ public class TokenGeneratorService {
   public String generateEnhancedLastMileGatewayToken(
       JumperConfig jc, String operation, String issuer, String publisherId, String subscriberId) {
 
+    String configuredAudience = resolveConfiguredAudience(jc);
+
     Jwt<?, Claims> authorizationTokenClaims =
         OauthTokenUtil.getAllClaimsFromToken(jc.getAuthorizationToken());
 
@@ -128,7 +132,11 @@ public class TokenGeneratorService {
     // A lone audience uses .single(...) rather than .add(...): jjwt only collapses the aud claim
     // to a plain JSON string (matching pre-migration wire format) via .single(...); .add(...)
     // always emits a JSON array, even when adding just one element.
-    if (Objects.nonNull(audiences) && !audiences.isEmpty()) {
+    // Provider audience precedence: configured audience, incoming token audiences, then the
+    // subscriberId fallback used by pub/sub calls.
+    if (Objects.nonNull(configuredAudience)) {
+      claims.audience().single(configuredAudience);
+    } else if (Objects.nonNull(audiences) && !audiences.isEmpty()) {
       if (audiences.size() == 1) {
         claims.audience().single(audiences.iterator().next());
       } else {
@@ -150,6 +158,50 @@ public class TokenGeneratorService {
   public String generateProviderLmsToken(
       JumperConfig jc, String operation, String issuer, String publisherId, String subscriberId) {
     return generateEnhancedLastMileGatewayToken(jc, operation, issuer, publisherId, subscriberId);
+  }
+
+  /**
+   * Resolves the provider-configured {@code aud} claim, if any.
+   *
+   * <p>Returns {@code null} when the provider configured no audience, in which case the incoming
+   * token's audiences and then the pub/sub {@code subscriberId} act as fallbacks.
+   *
+   * <p>{@code valueFrom: ConsumerClientId} resolves from {@link JumperConfig#getConsumer()}, which
+   * is derived from the incoming {@code Authorization} token. This is the original consumer's
+   * client id on every path, including the provider-side hop of a mesh call, where Kong restores
+   * the forwarded {@code consumer-token} into {@code Authorization} before invoking Jumper.
+   */
+  private static String resolveConfiguredAudience(JumperConfig jc) {
+    Optional<ConfiguredClaim> configuredClaim = jc.getConfiguredAudienceClaim();
+    if (configuredClaim.isEmpty()) {
+      return null;
+    }
+
+    ConfiguredClaim claim = configuredClaim.get();
+    boolean hasValue = Objects.nonNull(claim.getValue());
+    boolean hasValueFrom = Objects.nonNull(claim.getValueFrom());
+    if (hasValue == hasValueFrom) {
+      throw invalidAudienceConfiguration("exactly one of value or valueFrom must be set");
+    }
+    if (hasValue) {
+      if (StringUtils.isBlank(claim.getValue())) {
+        throw invalidAudienceConfiguration("value must not be blank");
+      }
+      return claim.getValue();
+    }
+    if (!Constants.CLAIM_VALUE_FROM_CONSUMER_CLIENT_ID.equals(claim.getValueFrom())) {
+      throw invalidAudienceConfiguration("unsupported valueFrom");
+    }
+    if (StringUtils.isBlank(jc.getConsumer())) {
+      throw invalidAudienceConfiguration("ConsumerClientId could not be resolved");
+    }
+    return jc.getConsumer();
+  }
+
+  private static ResponseStatusException invalidAudienceConfiguration(String reason) {
+    log.error("Invalid aud claim configuration: {}", reason);
+    return new ResponseStatusException(
+        HttpStatus.INTERNAL_SERVER_ERROR, "Invalid aud claim configuration: " + reason);
   }
 
   public String generateGatewayTokenForPublisher(String issuer, String realm) {

--- a/src/test/java/jumper/HeaderSteps.java
+++ b/src/test/java/jumper/HeaderSteps.java
@@ -83,6 +83,13 @@ public class HeaderSteps {
     baseSteps.setHttpHeadersOfRequest(RoutingConfigUtil.getSecondaryRouteHeaders(baseSteps));
   }
 
+  @Given("Secondary routing_config header set with configured audience")
+  public void secondaryRoutingConfigHeaderSetWithAudience() {
+    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
+    baseSteps.setHttpHeadersOfRequest(
+        RoutingConfigUtil.getSecondaryRouteHeadersWithAudience(baseSteps));
+  }
+
   @Given("Secondary routing_config with loadbalancing header set")
   public void secondaryRoutingConfigWithLoadbalancingHeaderSet() {
     baseSteps.authHeader = TokenUtil.getConsumerAccessToken();

--- a/src/test/java/jumper/JumperConfigSteps.java
+++ b/src/test/java/jumper/JumperConfigSteps.java
@@ -47,6 +47,14 @@ public class JumperConfigSteps {
             httpHeaders -> httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, getJcSecurity())));
   }
 
+  @And("jumperConfig with ConsumerClientId audience set")
+  public void setJumperConfigConsumerClientIdAudience() {
+    baseSteps.setHttpHeadersOfRequest(
+        baseSteps.httpHeadersOfRequest.andThen(
+            httpHeaders ->
+                httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, getJcConsumerClientIdAudience())));
+  }
+
   @And("jumperConfig oauth {string} set")
   public void setJumperConfigOauth(String jc_case) {
     baseSteps.setHttpHeadersOfRequest(

--- a/src/test/java/jumper/JumperConfigSteps.java
+++ b/src/test/java/jumper/JumperConfigSteps.java
@@ -47,12 +47,29 @@ public class JumperConfigSteps {
             httpHeaders -> httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, getJcSecurity())));
   }
 
-  @And("jumperConfig with ConsumerClientId audience set")
-  public void setJumperConfigConsumerClientIdAudience() {
+  @And("jumperConfig with {string} claim set")
+  public void setJumperConfigClaim(String jc_case) {
     baseSteps.setHttpHeadersOfRequest(
         baseSteps.httpHeadersOfRequest.andThen(
-            httpHeaders ->
-                httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, getJcConsumerClientIdAudience())));
+            httpHeaders -> {
+              switch (jc_case) {
+                case "ConsumerClientId audience":
+                  httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, getJcConsumerClientIdAudience());
+                  break;
+                case "literal audience":
+                  httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, getJcLiteralAudience());
+                  break;
+                case "unsupported valueFrom audience":
+                  httpHeaders.set(
+                      Constants.HEADER_JUMPER_CONFIG, getJcUnsupportedValueFromAudience());
+                  break;
+                case "forged azp":
+                  httpHeaders.set(Constants.HEADER_JUMPER_CONFIG, getJcForgedAzpClaim());
+                  break;
+                default:
+                  assert false : "not defined";
+              }
+            }));
   }
 
   @And("jumperConfig oauth {string} set")

--- a/src/test/java/jumper/VerificationSteps.java
+++ b/src/test/java/jumper/VerificationSteps.java
@@ -145,7 +145,9 @@ public class VerificationSteps {
           .expectHeader()
           .value(HttpHeaders.AUTHORIZATION, this::checkOneToken)
           .expectHeader()
-          .value(HttpHeaders.AUTHORIZATION, this::checkPubSub);
+          .value(HttpHeaders.AUTHORIZATION, this::checkPubSubIds)
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkSubscriberAudience);
     } else if (tokenType.equalsIgnoreCase("OneTokenWithScopes")) {
       this.baseSteps
           .getRequestExchange()
@@ -179,6 +181,15 @@ public class VerificationSteps {
           .getRequestExchange()
           .expectHeader()
           .value(HttpHeaders.AUTHORIZATION, this::checkOneTokenSimple)
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkConfiguredAudience);
+    } else if (tokenType.equalsIgnoreCase("OneTokenWithConfiguredAudienceOverridingFallbacks")) {
+      this.baseSteps
+          .getRequestExchange()
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkOneToken)
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkPubSubIds)
           .expectHeader()
           .value(HttpHeaders.AUTHORIZATION, this::checkConfiguredAudience);
     } else if (tokenType.equalsIgnoreCase("MeshToken")) {
@@ -278,11 +289,16 @@ public class VerificationSteps {
     assertNotNull(claimsFromToken.getBody().getIssuedAt());
   }
 
-  private void checkPubSub(String providerLmsToken) {
+  private void checkPubSubIds(String providerLmsToken) {
     Jwt<?, Claims> claimsFromToken = OauthTokenUtil.getAllClaimsFromToken(providerLmsToken);
 
     assertEquals(PUBSUB_PUBLISHER, claimsFromToken.getBody().get("publisherId", String.class));
     assertEquals(PUBSUB_SUBSCRIBER, claimsFromToken.getBody().get("subscriberId", String.class));
+  }
+
+  private void checkSubscriberAudience(String providerLmsToken) {
+    Jwt<?, Claims> claimsFromToken = OauthTokenUtil.getAllClaimsFromToken(providerLmsToken);
+
     assertEquals(Set.of(PUBSUB_SUBSCRIBER), claimsFromToken.getBody().getAudience());
   }
 

--- a/src/test/java/jumper/VerificationSteps.java
+++ b/src/test/java/jumper/VerificationSteps.java
@@ -167,6 +167,20 @@ public class VerificationSteps {
           .value(HttpHeaders.AUTHORIZATION, this::checkOneToken)
           .expectHeader()
           .value(HttpHeaders.AUTHORIZATION, this::checkMultipleAud);
+    } else if (tokenType.equalsIgnoreCase("OneTokenWithConfiguredConsumerAudience")) {
+      this.baseSteps
+          .getRequestExchange()
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkOneToken)
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkConfiguredConsumerAudience);
+    } else if (tokenType.equalsIgnoreCase("OneTokenSimpleWithConfiguredAudience")) {
+      this.baseSteps
+          .getRequestExchange()
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkOneTokenSimple)
+          .expectHeader()
+          .value(HttpHeaders.AUTHORIZATION, this::checkConfiguredAudience);
     } else if (tokenType.equalsIgnoreCase("MeshToken")) {
       this.baseSteps
           .getRequestExchange()
@@ -288,6 +302,18 @@ public class VerificationSteps {
     Jwt<?, Claims> claimsFromToken = OauthTokenUtil.getAllClaimsFromToken(providerLmsToken);
 
     assertEquals(Set.of("testAudience1", "testAudience2"), claimsFromToken.getBody().getAudience());
+  }
+
+  private void checkConfiguredConsumerAudience(String providerLmsToken) {
+    Jwt<?, Claims> claimsFromToken = OauthTokenUtil.getAllClaimsFromToken(providerLmsToken);
+
+    assertEquals(Set.of(CONSUMER), claimsFromToken.getBody().getAudience());
+  }
+
+  private void checkConfiguredAudience(String providerLmsToken) {
+    Jwt<?, Claims> claimsFromToken = OauthTokenUtil.getAllClaimsFromToken(providerLmsToken);
+
+    assertEquals(Set.of(CONFIGURED_AUDIENCE), claimsFromToken.getBody().getAudience());
   }
 
   private void checkProviderIdpMeshToken(String providerIdpToken) {

--- a/src/test/java/jumper/config/Config.java
+++ b/src/test/java/jumper/config/Config.java
@@ -10,6 +10,7 @@ public class Config {
   public static final String CONSUMER_EXTERNAL_CONFIGURED = "external_configured";
   public static final String CONSUMER_EXTERNAL_HEADER = "external_header";
   public static final String SCOPES = "scope1 scope2";
+  public static final String CONFIGURED_AUDIENCE = "configured-audience";
   public static final String OAUTH_SCOPE_CONFIGURED = "scope_configured";
   public static final String OAUTH_SCOPE_HEADER = "scope_header";
   public static final String ORIGIN_STARGATE = "https://zone.local.de";

--- a/src/test/java/jumper/service/TokenGeneratorServiceTest.java
+++ b/src/test/java/jumper/service/TokenGeneratorServiceTest.java
@@ -238,6 +238,32 @@ class TokenGeneratorServiceTest {
   }
 
   @Test
+  @DisplayName("a configured audience survives fillProcessingInfo and wins over a header audience")
+  void configuredAudience_winsOverConflictingHeaderAudience() {
+    // arrange: model the failover path, where the JumperConfig comes from the selected
+    // routing_config entry while the jumper_config header carries a competing audience
+    String consumerToken = consumerTokenWithAudiences(List.of());
+    JumperConfig routingEntry = new JumperConfig();
+    routingEntry.setRemoteApiUrl("http://localhost:1080/provider");
+    setConfiguredAudience(routingEntry, configuredAudience("routing-entry-audience", null));
+
+    JumperConfig headerConfig = new JumperConfig();
+    setConfiguredAudience(headerConfig, configuredAudience("header-audience", null));
+
+    // act
+    routingEntry.fillProcessingInfo(
+        MockServerHttpRequest.get("/provider")
+            .header(Constants.HEADER_AUTHORIZATION, "Bearer " + consumerToken)
+            .header(Constants.HEADER_JUMPER_CONFIG, JumperConfig.toJsonBase64(headerConfig))
+            .build());
+    String providerLmsToken =
+        tokenGeneratorService.generateProviderLmsToken(routingEntry, "GET", ISSUER, null, null);
+
+    // assert: fillProcessingInfo does not re-source claims, so the routing entry keeps its own
+    assertThat(parse(providerLmsToken).getAudience()).containsExactly("routing-entry-audience");
+  }
+
+  @Test
   @DisplayName("a configured non-aud claim key is ignored")
   void configuredNonAudClaimKey_isIgnored() {
     // arrange
@@ -255,6 +281,24 @@ class TokenGeneratorServiceTest {
     // assert: neither the audience nor azp is influenced by a non-aud entry
     assertThat(claims.getAudience()).containsExactly("consumerAud");
     assertThat(claims.get(Constants.TOKEN_CLAIM_AZP, String.class)).isEqualTo("stargate");
+  }
+
+  @Test
+  @DisplayName("only the first of several configured aud entries is applied")
+  void multipleConfiguredAudiences_firstWins() {
+    // arrange: the control plane schema allows one aud claim, so this models config drift
+    JumperConfig jc = jumperConfig(consumerTokenWithAudiences(List.of("consumerAud")));
+    setConfiguredAudience(
+        jc,
+        configuredAudience("first-audience", null),
+        configuredAudience("second-audience", null));
+
+    // act
+    String providerLmsToken =
+        tokenGeneratorService.generateProviderLmsToken(jc, "GET", ISSUER, null, null);
+
+    // assert
+    assertThat(parse(providerLmsToken).getAudience()).containsExactly("first-audience");
   }
 
   @Test
@@ -347,10 +391,10 @@ class TokenGeneratorServiceTest {
     return jc;
   }
 
-  private static void setConfiguredAudience(JumperConfig jc, ConfiguredClaim claim) {
-    HashMap<String, List<ConfiguredClaim>> claims = new HashMap<>();
-    claims.put(Constants.CLAIMS_DEFAULT_KEY, List.of(claim));
-    jc.setClaims(claims);
+  private static void setConfiguredAudience(JumperConfig jc, ConfiguredClaim... claims) {
+    HashMap<String, List<ConfiguredClaim>> claimsMap = new HashMap<>();
+    claimsMap.put(Constants.CLAIMS_DEFAULT_KEY, List.of(claims));
+    jc.setClaims(claimsMap);
   }
 
   private static ConfiguredClaim configuredAudience(String value, String valueFrom) {
@@ -377,7 +421,7 @@ class TokenGeneratorServiceTest {
             "blank value", configuredAudience(" ", null), "consumer", "value must not be blank"),
         Arguments.of(
             "unsupported valueFrom",
-            configuredAudience(null, "ProviderClientId"),
+            configuredAudience(null, "UnsupportedSource"),
             "consumer",
             "unsupported valueFrom"),
         Arguments.of(

--- a/src/test/java/jumper/service/TokenGeneratorServiceTest.java
+++ b/src/test/java/jumper/service/TokenGeneratorServiceTest.java
@@ -6,6 +6,7 @@ package jumper.service;
 
 import static jumper.config.Config.LOCAL_ISSUER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -14,8 +15,12 @@ import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.Jwts;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Stream;
+import jumper.Constants;
 import jumper.model.config.JumperConfig;
+import jumper.model.config.JumperConfig.ConfiguredClaim;
 import jumper.model.config.KeyInfo;
 import jumper.util.AccessToken;
 import jumper.util.OauthTokenUtil;
@@ -25,6 +30,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.web.server.ResponseStatusException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
@@ -185,6 +194,108 @@ class TokenGeneratorServiceTest {
   }
 
   @Test
+  @DisplayName("configured audience overrides incoming audience and subscriberId")
+  void configuredAudience_hasHighestPrecedence() {
+    // arrange
+    JumperConfig jc = jumperConfig(consumerTokenWithAudiences(List.of("consumerAud")));
+    setConfiguredAudience(jc, configuredAudience("provider-audience", null));
+
+    // act
+    String providerLmsToken =
+        tokenGeneratorService.generateProviderLmsToken(jc, "GET", ISSUER, null, "subscriber-1");
+
+    // assert
+    assertThat(parse(providerLmsToken).getAudience()).containsExactly("provider-audience");
+  }
+
+  @Test
+  @DisplayName("ConsumerClientId resolves the original consumer on the provider side of a mesh hop")
+  void consumerClientId_resolvesOriginalConsumerAfterMeshHop() {
+    // arrange: model the provider-zone hop of a mesh call. The consumer gateway forwards the
+    // original consumer token in `consumer-token`; Kong in the provider zone moves it back into
+    // `Authorization` before invoking Jumper. So `consumer` is re-sourced by fillProcessingInfo
+    // from the original consumer token, not from the provider-IdP mesh token.
+    String consumerToken = consumerTokenWithAudiences(List.of("consumerAud"));
+    JumperConfig providerZoneConfig = new JumperConfig();
+    providerZoneConfig.setRemoteApiUrl("http://localhost:1080/provider");
+    setConfiguredAudience(
+        providerZoneConfig,
+        configuredAudience(null, Constants.CLAIM_VALUE_FROM_CONSUMER_CLIENT_ID));
+
+    providerZoneConfig.fillProcessingInfo(
+        MockServerHttpRequest.get("/provider")
+            .header(Constants.HEADER_AUTHORIZATION, "Bearer " + consumerToken)
+            .build());
+
+    // act
+    String providerLmsToken =
+        tokenGeneratorService.generateProviderLmsToken(
+            providerZoneConfig, "GET", ISSUER, null, null);
+
+    // assert: the configured claims survive fillProcessingInfo and resolve to the real consumer
+    assertThat(providerZoneConfig.getConsumer()).isEqualTo("eni--local-team--local-app");
+    assertThat(parse(providerLmsToken).getAudience()).containsExactly("eni--local-team--local-app");
+  }
+
+  @Test
+  @DisplayName("a configured non-aud claim key is ignored")
+  void configuredNonAudClaimKey_isIgnored() {
+    // arrange
+    JumperConfig jc = jumperConfig(consumerTokenWithAudiences(List.of("consumerAud")));
+    ConfiguredClaim azpClaim = new ConfiguredClaim();
+    azpClaim.setKey(Constants.TOKEN_CLAIM_AZP);
+    azpClaim.setValue("forged");
+    setConfiguredAudience(jc, azpClaim);
+
+    // act
+    String providerLmsToken =
+        tokenGeneratorService.generateProviderLmsToken(jc, "GET", ISSUER, null, null);
+    Claims claims = parse(providerLmsToken);
+
+    // assert: neither the audience nor azp is influenced by a non-aud entry
+    assertThat(claims.getAudience()).containsExactly("consumerAud");
+    assertThat(claims.get(Constants.TOKEN_CLAIM_AZP, String.class)).isEqualTo("stargate");
+  }
+
+  @Test
+  @DisplayName("a configured audience is emitted as a JSON string, not a one-element array")
+  void configuredAudience_emitsPlainStringOnTheWire() {
+    // arrange
+    JumperConfig jc = jumperConfig(consumerTokenWithAudiences(List.of("aud1", "aud2")));
+    setConfiguredAudience(jc, configuredAudience("provider-audience", null));
+
+    // act
+    String providerLmsToken =
+        tokenGeneratorService.generateProviderLmsToken(jc, "GET", ISSUER, null, null);
+
+    // assert: Claims#getAudience() normalizes both wire forms, so assert on the raw payload
+    JsonNode aud = rawPayloadJson(providerLmsToken).get("aud");
+    assertThat(aud.isString()).isTrue();
+    assertThat(aud.asString()).isEqualTo("provider-audience");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("invalidAudienceConfigurations")
+  void invalidConfiguredAudience_returnsInternalServerError(
+      String description, ConfiguredClaim claim, String consumer, String expectedReason) {
+    // arrange
+    JumperConfig jc = jumperConfig(consumerTokenWithAudiences(List.of()));
+    jc.setConsumer(consumer);
+    setConfiguredAudience(jc, claim);
+
+    // act
+    ResponseStatusException exception =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> tokenGeneratorService.generateProviderLmsToken(jc, "GET", ISSUER, null, null));
+
+    // assert
+    assertThat(exception.getStatusCode().value()).isEqualTo(500);
+    assertThat(exception.getReason())
+        .isEqualTo("Invalid aud claim configuration: " + expectedReason);
+  }
+
+  @Test
   @DisplayName("createJwtTokenFromKey rejects an RS256 key weaker than 2048 bits with 401")
   void weakKey_isRejectedWith401() {
     // arrange
@@ -234,6 +345,46 @@ class TokenGeneratorServiceTest {
     jc.setConsumerOriginStargate("https://zone.local.de");
     jc.setEnvName("localEnv");
     return jc;
+  }
+
+  private static void setConfiguredAudience(JumperConfig jc, ConfiguredClaim claim) {
+    HashMap<String, List<ConfiguredClaim>> claims = new HashMap<>();
+    claims.put(Constants.CLAIMS_DEFAULT_KEY, List.of(claim));
+    jc.setClaims(claims);
+  }
+
+  private static ConfiguredClaim configuredAudience(String value, String valueFrom) {
+    ConfiguredClaim claim = new ConfiguredClaim();
+    claim.setKey(Constants.TOKEN_CLAIM_AUD);
+    claim.setValue(value);
+    claim.setValueFrom(valueFrom);
+    return claim;
+  }
+
+  private static Stream<Arguments> invalidAudienceConfigurations() {
+    return Stream.of(
+        Arguments.of(
+            "missing value and valueFrom",
+            configuredAudience(null, null),
+            "consumer",
+            "exactly one of value or valueFrom must be set"),
+        Arguments.of(
+            "value and valueFrom both set",
+            configuredAudience("audience", Constants.CLAIM_VALUE_FROM_CONSUMER_CLIENT_ID),
+            "consumer",
+            "exactly one of value or valueFrom must be set"),
+        Arguments.of(
+            "blank value", configuredAudience(" ", null), "consumer", "value must not be blank"),
+        Arguments.of(
+            "unsupported valueFrom",
+            configuredAudience(null, "ProviderClientId"),
+            "consumer",
+            "unsupported valueFrom"),
+        Arguments.of(
+            "unresolved ConsumerClientId",
+            configuredAudience(null, Constants.CLAIM_VALUE_FROM_CONSUMER_CLIENT_ID),
+            null,
+            "ConsumerClientId could not be resolved"));
   }
 
   private static Claims parse(String token) {

--- a/src/test/java/jumper/util/JumperConfigUtil.java
+++ b/src/test/java/jumper/util/JumperConfigUtil.java
@@ -26,6 +26,27 @@ public class JumperConfigUtil {
     return toJsonBase64(jc);
   }
 
+  public static String getJcConsumerClientIdAudience() {
+    JumperConfig jc = new JumperConfig();
+    jc.setClaims(defaultClaims(audienceClaim(null, Constants.CLAIM_VALUE_FROM_CONSUMER_CLIENT_ID)));
+    return toJsonBase64(jc);
+  }
+
+  public static HashMap<String, List<JumperConfig.ConfiguredClaim>> defaultClaims(
+      JumperConfig.ConfiguredClaim claim) {
+    HashMap<String, List<JumperConfig.ConfiguredClaim>> claims = new HashMap<>();
+    claims.put(Constants.CLAIMS_DEFAULT_KEY, List.of(claim));
+    return claims;
+  }
+
+  public static JumperConfig.ConfiguredClaim audienceClaim(String value, String valueFrom) {
+    JumperConfig.ConfiguredClaim claim = new JumperConfig.ConfiguredClaim();
+    claim.setKey(Constants.TOKEN_CLAIM_AUD);
+    claim.setValue(value);
+    claim.setValueFrom(valueFrom);
+    return claim;
+  }
+
   public static String getJcBasicAuthConsumer(String id) {
     HashMap<String, BasicAuthCredentials> basicAuthCredentialsHashMap = new HashMap<>();
     BasicAuthCredentials ba = new BasicAuthCredentials();

--- a/src/test/java/jumper/util/JumperConfigUtil.java
+++ b/src/test/java/jumper/util/JumperConfigUtil.java
@@ -32,6 +32,26 @@ public class JumperConfigUtil {
     return toJsonBase64(jc);
   }
 
+  public static String getJcLiteralAudience() {
+    JumperConfig jc = new JumperConfig();
+    jc.setClaims(defaultClaims(audienceClaim(CONFIGURED_AUDIENCE, null)));
+    return toJsonBase64(jc);
+  }
+
+  /** ConsumerClientId is the only supported valueFrom, so this value is rejected. */
+  public static String getJcUnsupportedValueFromAudience() {
+    JumperConfig jc = new JumperConfig();
+    jc.setClaims(defaultClaims(audienceClaim(null, "UnsupportedSource")));
+    return toJsonBase64(jc);
+  }
+
+  /** Only the {@code aud} key is consumed, so this entry must never reach the generated token. */
+  public static String getJcForgedAzpClaim() {
+    JumperConfig jc = new JumperConfig();
+    jc.setClaims(defaultClaims(configuredClaim(Constants.TOKEN_CLAIM_AZP, "forged", null)));
+    return toJsonBase64(jc);
+  }
+
   public static HashMap<String, List<JumperConfig.ConfiguredClaim>> defaultClaims(
       JumperConfig.ConfiguredClaim claim) {
     HashMap<String, List<JumperConfig.ConfiguredClaim>> claims = new HashMap<>();
@@ -40,8 +60,13 @@ public class JumperConfigUtil {
   }
 
   public static JumperConfig.ConfiguredClaim audienceClaim(String value, String valueFrom) {
+    return configuredClaim(Constants.TOKEN_CLAIM_AUD, value, valueFrom);
+  }
+
+  public static JumperConfig.ConfiguredClaim configuredClaim(
+      String key, String value, String valueFrom) {
     JumperConfig.ConfiguredClaim claim = new JumperConfig.ConfiguredClaim();
-    claim.setKey(Constants.TOKEN_CLAIM_AUD);
+    claim.setKey(key);
     claim.setValue(value);
     claim.setValueFrom(valueFrom);
     return claim;

--- a/src/test/java/jumper/util/RoutingConfigUtil.java
+++ b/src/test/java/jumper/util/RoutingConfigUtil.java
@@ -23,6 +23,14 @@ public class RoutingConfigUtil {
     };
   }
 
+  public static Consumer<HttpHeaders> getSecondaryRouteHeadersWithAudience(BaseSteps baseSteps) {
+    return httpHeaders -> {
+      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
+      httpHeaders.set(
+          Constants.HEADER_ROUTING_CONFIG, getRcSecondaryWithAudience(baseSteps.getId()));
+    };
+  }
+
   public static Consumer<HttpHeaders> getSecondaryRouteHeadersWithLoadbalancing(
       BaseSteps baseSteps) {
     return httpHeaders -> {
@@ -42,6 +50,14 @@ public class RoutingConfigUtil {
   public static String getRcSecondary(String id) {
     // proxy + real
     return toJsonBase64(List.of(getProxyRouteJc(REMOTE_ZONE_NAME, id), getRealRouteJc()));
+  }
+
+  public static String getRcSecondaryWithAudience(String id) {
+    // proxy + real, where the real route carries a provider-configured literal audience
+    JumperConfig realRoute = getRealRouteJc();
+    realRoute.setClaims(
+        JumperConfigUtil.defaultClaims(JumperConfigUtil.audienceClaim(CONFIGURED_AUDIENCE, null)));
+    return toJsonBase64(List.of(getProxyRouteJc(REMOTE_ZONE_NAME, id), realRoute));
   }
 
   public static String getRcSecondaryLoadbalancing(String id) {

--- a/src/test/resources/features/authorizationHeader.feature
+++ b/src/test/resources/features/authorizationHeader.feature
@@ -62,6 +62,14 @@ Feature: proper authorization token reaches provider endpoint
     Then API Provider receives authorization OneTokenWithMultipleAud
     And API consumer receives a 200 status code
 
+  Scenario: ConsumerClientId configured as audience resolves to the calling application
+    Given RealRoute headers are set
+    And jumperConfig with ConsumerClientId audience set
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives authorization OneTokenWithConfiguredConsumerAudience
+    And API consumer receives a 200 status code
+
   Scenario: Consumer calls proxy route and realm header contains several values, correct issuer set in OneToken
     Given RealRoute headers are set
     And several realm fields are contained in the header

--- a/src/test/resources/features/authorizationHeader.feature
+++ b/src/test/resources/features/authorizationHeader.feature
@@ -64,10 +64,38 @@ Feature: proper authorization token reaches provider endpoint
 
   Scenario: ConsumerClientId configured as audience resolves to the calling application
     Given RealRoute headers are set
-    And jumperConfig with ConsumerClientId audience set
+    And jumperConfig with "ConsumerClientId audience" claim set
     And API provider set to respond with a 200 status code
     When consumer calls the proxy route
     Then API Provider receives authorization OneTokenWithConfiguredConsumerAudience
+    And API consumer receives a 200 status code
+
+  Scenario: Configured audience wins when an incoming token audience and pub/sub subscriber are both present
+    Given RealRoute headers are set
+    And authorization token with aud set
+    And pub sub contained in the header
+    And jumperConfig with "literal audience" claim set
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives authorization OneTokenWithConfiguredAudienceOverridingFallbacks
+    And API consumer receives a 200 status code
+
+  Scenario: Configured audience wins over the pub/sub subscriber fallback when no incoming token audience is present
+    Given RealRoute headers are set
+    And pub sub contained in the header
+    And jumperConfig with "literal audience" claim set
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives authorization OneTokenWithConfiguredAudienceOverridingFallbacks
+    And API consumer receives a 200 status code
+
+  Scenario: Configured claim with a non-aud key is ignored and cannot forge azp
+    Given RealRoute headers are set
+    And authorization token with aud set
+    And jumperConfig with "forged azp" claim set
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives authorization OneTokenWithAud
     And API consumer receives a 200 status code
 
   Scenario: Consumer calls proxy route and realm header contains several values, correct issuer set in OneToken

--- a/src/test/resources/features/errorResponse.feature
+++ b/src/test/resources/features/errorResponse.feature
@@ -17,6 +17,13 @@ Feature: proper error message returned based on conditions
     Then API consumer receives a 500 status code
     And error response contains msg "Token not provided, but expected" error "Internal Server Error" status 500
 
+  Scenario: Provider configures an unsupported valueFrom for the audience claim
+    Given RealRoute headers are set
+    And jumperConfig with "unsupported valueFrom audience" claim set
+    When consumer calls the proxy route
+    Then API consumer receives a 500 status code
+    And error response contains msg "Invalid aud claim configuration: unsupported valueFrom" error "Internal Server Error" status 500
+
   Scenario: mesh IDP drops connection
     Given ProxyRoute headers are set
     And IDP set to drop connection

--- a/src/test/resources/features/failover.feature
+++ b/src/test/resources/features/failover.feature
@@ -22,6 +22,14 @@ Feature: request containing routing_config properly handled
     Then API Provider receives default bearer authorization headers
     Then API Provider receives authorization OneTokenSimple
 
+  Scenario: Consumer calls secondary provider route with a configured audience
+    Given Secondary routing_config header set with configured audience
+    And skip zone header set
+    And API provider set to respond on provider path
+    When consumer calls the proxy route without base path
+    Then API Provider receives default bearer authorization headers
+    Then API Provider receives authorization OneTokenSimpleWithConfiguredAudience
+
   Scenario: Consumer calls proxy route with secondary config and zone is unhealthy, provider called
     Given Secondary routing_config header set
     And set zone state to unhealthy


### PR DESCRIPTION
## What

Add Jumper support for provider-configured `aud` claims emitted by telekom/controlplane#491.

Provider LMS tokens now support:

- A literal configured audience.
- `valueFrom: ConsumerClientId`, resolved from the incoming token's `clientId`.
- Direct and failover request paths.

## Audience precedence

Provider-token audiences are selected in this order:

1. Configured provider audience.
2. Audience values from the incoming token.
3. `x-pubsub-subscriber-id` fallback.

This preserves existing behavior when no audience is configured.

## Mesh behavior

Configured provider claims apply only where Jumper mints the provider-facing token, so they are not applied on mesh routes — the consumer zone forwards a token obtained from the provider zone's identity provider.

At the provider gateway, `ConsumerClientId` resolves from the `clientId` of the incoming `Authorization` token. On a mesh call Kong restores the forwarded `consumer-token` into `Authorization` before invoking Jumper, so this is the original consumer on every path.

## Validation

An explicitly configured `aud` must define exactly one of `value` or `valueFrom`. Unsupported or unresolvable configurations return HTTP 500 with a bounded diagnostic message.

Multiple configured `aud` entries log a warning and the first entry is applied, rather than failing the request.

The control plane remains responsible for schema constraints such as supported claim keys, sources, and maximum value length.

## Tests

- Configured audience precedence, including a three-way case with an incoming token audience and pub/sub subscriber present, plus a case isolating the subscriber fallback.
- `ConsumerClientId` resolution from the incoming token.
- Invalid audience configurations, including an end-to-end scenario asserting HTTP 500 and its exact message.
- A configured non-`aud` claim key is ignored and cannot forge `azp`.
- A singular configured `aud` is emitted as a JSON string, asserted on the raw payload.
- Only the first of several configured `aud` entries is applied.
- Direct-route and failover Cucumber coverage.

`./mvnw clean test`: 305 tests passed, including 146 Cucumber scenarios.
