### PR TITLE
feat(security): surface firewall rejections in logs and traces

### DIFF
--- a/src/main/java/jumper/config/SecurityConfiguration.java
+++ b/src/main/java/jumper/config/SecurityConfiguration.java
@@ -4,11 +4,14 @@
 
 package jumper.config;
 
+import io.micrometer.tracing.Tracer;
+import jumper.exception.LoggingServerExchangeRejectedHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import org.springframework.security.web.server.firewall.ServerExchangeRejectedHandler;
 import org.springframework.security.web.server.firewall.StrictServerWebExchangeFirewall;
 import org.springframework.web.server.session.WebSessionManager;
 import reactor.core.publisher.Mono;
@@ -54,6 +57,20 @@ public class SecurityConfiguration {
     firewall.setAllowUrlEncodedPeriod(true);
 
     return firewall;
+  }
+
+  /**
+   * Replaces Spring Security's default exchange rejection handling, which answers {@code 400 Bad
+   * Request} but only logs at {@code DEBUG} and bypasses {@link
+   * jumper.exception.JsonErrorWebExceptionHandler}.
+   *
+   * @param tracer used to attach a rejection event and reason tag to the current span
+   * @return handler that keeps the 400 response but logs at WARN and records the rejection on the
+   *     current observation
+   */
+  @Bean
+  public ServerExchangeRejectedHandler serverExchangeRejectedHandler(Tracer tracer) {
+    return new LoggingServerExchangeRejectedHandler(tracer);
   }
 
   /**

--- a/src/main/java/jumper/exception/LoggingServerExchangeRejectedHandler.java
+++ b/src/main/java/jumper/exception/LoggingServerExchangeRejectedHandler.java
@@ -40,12 +40,17 @@ public class LoggingServerExchangeRejectedHandler implements ServerExchangeRejec
   /** Span tag holding the (sanitized) firewall rejection reason. */
   public static final String SPAN_TAG_REASON = "firewall.rejection.reason";
 
+  /** Marker appended to values truncated at {@link #MAX_VALUE_LENGTH}. */
+  static final String TRUNCATION_MARKER = "…(truncated)";
+
+  /** Cap for client-controlled values; the firewall message prefix is ~60 characters. */
+  static final int MAX_VALUE_LENGTH = 256;
+
   private final Tracer tracer;
   private final ServerExchangeRejectedHandler delegate;
 
   public LoggingServerExchangeRejectedHandler(Tracer tracer) {
-    // Default status of HttpStatusExchangeRejectedHandler is 400 BAD_REQUEST; delegating keeps the
-    // response contract identical to the Spring Security default.
+    // HttpStatusExchangeRejectedHandler defaults to 400, matching Spring Security's behaviour
     this(tracer, new HttpStatusExchangeRejectedHandler());
   }
 
@@ -86,29 +91,38 @@ public class LoggingServerExchangeRejectedHandler implements ServerExchangeRejec
   }
 
   /**
-   * Escapes ISO control characters so client-controlled content cannot forge log lines or break
-   * span attributes.
+   * Truncates and escapes a client-controlled value for logging and span tagging.
    *
-   * @param value the raw, potentially client-controlled value
-   * @return the value with every control character replaced by its {@code \\uXXXX} escape
+   * <p>The cap matters because the firewall embeds the offending header or parameter verbatim and
+   * Netty accepts up to 8 KB of it. Escaping control characters is defense in depth; the structured
+   * console, OTLP and Zipkin encoders already escape them.
    */
   private static String sanitize(String value) {
     if (Objects.isNull(value)) {
       return "";
     }
 
-    StringBuilder sanitized = new StringBuilder(value.length());
-    value
-        .codePoints()
-        .forEach(
-            codePoint -> {
-              if (Character.isISOControl(codePoint)) {
-                sanitized.append(String.format("\\u%04x", codePoint));
-              } else {
-                sanitized.appendCodePoint(codePoint);
-              }
-            });
+    boolean truncated = value.length() > MAX_VALUE_LENGTH;
+    String capped = truncated ? value.substring(0, MAX_VALUE_LENGTH) : value;
 
-    return sanitized.toString();
+    // a lone surrogate left by the cut is not encodable as UTF-8, which OTLP requires
+    if (truncated
+        && !capped.isEmpty()
+        && Character.isHighSurrogate(capped.charAt(capped.length() - 1))) {
+      capped = capped.substring(0, capped.length() - 1);
+    }
+
+    // isISOControl only matches BMP code points, so iterating chars is sufficient
+    StringBuilder escaped = new StringBuilder(capped.length());
+    for (int i = 0; i < capped.length(); i++) {
+      char character = capped.charAt(i);
+      if (Character.isISOControl(character)) {
+        escaped.append(String.format("\\u%04x", (int) character));
+      } else {
+        escaped.append(character);
+      }
+    }
+
+    return truncated ? escaped.append(TRUNCATION_MARKER).toString() : escaped.toString();
   }
 }

--- a/src/main/java/jumper/exception/LoggingServerExchangeRejectedHandler.java
+++ b/src/main/java/jumper/exception/LoggingServerExchangeRejectedHandler.java
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.exception;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.observation.ServerRequestObservationContext;
+import org.springframework.security.web.server.firewall.HttpStatusExchangeRejectedHandler;
+import org.springframework.security.web.server.firewall.ServerExchangeRejectedException;
+import org.springframework.security.web.server.firewall.ServerExchangeRejectedHandler;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Makes {@link org.springframework.security.web.server.firewall.ServerWebExchangeFirewall}
+ * rejections observable.
+ *
+ * <p>This handler keeps the upstream response behaviour (it delegates for the status code) and
+ * adds:
+ *
+ * <ul>
+ *   <li>a {@code WARN} log line carrying method, path and rejection reason,
+ *   <li>a {@value #SPAN_EVENT} span event plus a {@value #SPAN_TAG_REASON} tag, and
+ *   <li>the rejection recorded as the error of the current server observation, so the {@code
+ *       http.server.requests} span is marked as failed even when no span is bound to the calling
+ *       thread.
+ * </ul>
+ */
+@Slf4j
+public class LoggingServerExchangeRejectedHandler implements ServerExchangeRejectedHandler {
+
+  /** Span event name recorded when the firewall rejects an exchange. */
+  public static final String SPAN_EVENT = "firewall.rejected";
+
+  /** Span tag holding the (sanitized) firewall rejection reason. */
+  public static final String SPAN_TAG_REASON = "firewall.rejection.reason";
+
+  private final Tracer tracer;
+  private final ServerExchangeRejectedHandler delegate;
+
+  public LoggingServerExchangeRejectedHandler(Tracer tracer) {
+    // Default status of HttpStatusExchangeRejectedHandler is 400 BAD_REQUEST; delegating keeps the
+    // response contract identical to the Spring Security default.
+    this(tracer, new HttpStatusExchangeRejectedHandler());
+  }
+
+  LoggingServerExchangeRejectedHandler(Tracer tracer, ServerExchangeRejectedHandler delegate) {
+    this.tracer = tracer;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Mono<Void> handle(ServerWebExchange exchange, ServerExchangeRejectedException ex) {
+    // defer so the log/span side effects run on subscription, in step with the delegate
+    return Mono.defer(
+        () -> {
+          record(exchange, ex);
+          return delegate.handle(exchange, ex);
+        });
+  }
+
+  private void record(ServerWebExchange exchange, ServerExchangeRejectedException ex) {
+    ServerHttpRequest request = exchange.getRequest();
+    String reason = sanitize(ex.getMessage());
+
+    log.warn(
+        "Request rejected by security firewall: method={}, path={}, reason={}",
+        request.getMethod(),
+        sanitize(request.getPath().value()),
+        reason);
+
+    Span span = tracer.currentSpan();
+    if (Objects.nonNull(span)) {
+      span.event(SPAN_EVENT);
+      span.tag(SPAN_TAG_REASON, reason);
+    }
+
+    // Independent of thread-bound tracing state: marks the server observation as errored.
+    ServerRequestObservationContext.findCurrent(exchange.getAttributes())
+        .ifPresent(context -> context.setError(ex));
+  }
+
+  /**
+   * Escapes ISO control characters so client-controlled content cannot forge log lines or break
+   * span attributes.
+   *
+   * @param value the raw, potentially client-controlled value
+   * @return the value with every control character replaced by its {@code \\uXXXX} escape
+   */
+  private static String sanitize(String value) {
+    if (Objects.isNull(value)) {
+      return "";
+    }
+
+    StringBuilder sanitized = new StringBuilder(value.length());
+    value
+        .codePoints()
+        .forEach(
+            codePoint -> {
+              if (Character.isISOControl(codePoint)) {
+                sanitized.append(String.format("\\u%04x", codePoint));
+              } else {
+                sanitized.appendCodePoint(codePoint);
+              }
+            });
+
+    return sanitized.toString();
+  }
+}

--- a/src/test/java/jumper/exception/FirewallRejectionIntegrationTest.java
+++ b/src/test/java/jumper/exception/FirewallRejectionIntegrationTest.java
@@ -4,14 +4,28 @@
 
 package jumper.exception;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.net.URI;
+import java.util.List;
+import java.util.function.Consumer;
+import jumper.Constants;
+import jumper.config.Config;
+import jumper.util.TokenUtil;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,20 +35,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.micrometer.tracing.test.autoconfigure.AutoConfigureTracing;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.web.server.firewall.ServerExchangeRejectedHandler;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
- * Verifies end to end that {@link LoggingServerExchangeRejectedHandler} is actually wired into the
- * Spring Security {@code WebFilterChainProxy}.
+ * Verifies that {@link LoggingServerExchangeRejectedHandler} is wired into the Spring Security
+ * filter chain. The status code cannot prove it, since the default handler also answers {@code
+ * 400}, so the WARN line doubles as the wiring assertion.
  *
- * <p>The status code alone cannot prove this, since Spring Security's default handler also answers
- * {@code 400}. The WARN log line is what distinguishes the two, so it doubles as the wiring
- * assertion.
- *
- * <p>The URL under test reproduces a real production request in which a stray tab ({@code %09})
- * prefixed a query parameter name.
+ * <p>Both tests send the same request against an upstream stubbed to {@code 200}; only the stray
+ * tab ({@code %09}) in front of the parameter name differs.
  */
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -44,19 +56,41 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @AutoConfigureWebTestClient(timeout = "PT10S")
 class FirewallRejectionIntegrationTest {
 
+  private static final String QUERY_PARAM = "u_ressource_type";
+  private static final String QUERY_VALUE = "IPLSPortComp";
+  private static final String REQUEST_PATH =
+      Constants.PROXY_ROOT_PATH_PREFIX + Config.BASE_PATH + "/getItems";
+
+  static WireMockServer mockUpstream;
+
   @Autowired WebTestClient webTestClient;
 
   @Autowired ServerExchangeRejectedHandler rejectedHandler;
 
-  // absolute URIs are required below, since WebTestClient#uri(URI) bypasses the configured base URL
   @Value("${local.server.port}")
   private int port;
 
   private ListAppender<ILoggingEvent> logAppender;
   private ch.qos.logback.classic.Logger logger;
 
+  @BeforeAll
+  static void startMockUpstream() {
+    mockUpstream = new WireMockServer(options().dynamicPort());
+    mockUpstream.start();
+    mockUpstream.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
+  }
+
+  @AfterAll
+  static void stopMockUpstream() {
+    if (mockUpstream != null) {
+      mockUpstream.stop();
+    }
+  }
+
   @BeforeEach
   void attachAppender() {
+    mockUpstream.resetRequests();
+
     LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
     logger = context.getLogger(LoggingServerExchangeRejectedHandler.class);
     logAppender = new ListAppender<>();
@@ -79,11 +113,11 @@ class FirewallRejectionIntegrationTest {
   @Test
   @DisplayName("a tab encoded parameter name is rejected with 400 and logged at WARN")
   void tabInParameterName_isRejectedAndLogged() {
-    // act: %09 decodes to a TAB, which is an ISO control character and therefore not an
-    // allowed parameter name for StrictServerWebExchangeFirewall
+    // act: %09 decodes to a TAB, which StrictServerWebExchangeFirewall rejects
     webTestClient
         .get()
-        .uri(rawUri("/proxy/b2b-assura/ci-search/v1/getItems?%09u_ressource_type=IPLSPortComp"))
+        .uri(rawUri(REQUEST_PATH + "?%09" + QUERY_PARAM + "=" + QUERY_VALUE))
+        .headers(routingHeaders())
         .exchange()
         .expectStatus()
         .isBadRequest();
@@ -94,29 +128,51 @@ class FirewallRejectionIntegrationTest {
     assertThat(event.getLevel()).isEqualTo(Level.WARN);
     assertThat(event.getFormattedMessage())
         .contains("Request rejected by security firewall")
-        .contains("u_ressource_type")
+        .contains(QUERY_PARAM)
         .contains("\\u0009");
+    assertThat(mockUpstream.findAll(anyRequestedFor(anyUrl()))).isEmpty();
   }
 
   @Test
-  @DisplayName("the same URL without the tab is not rejected by the firewall")
-  void withoutTab_isNotRejectedByFirewall() {
-    // act: same request minus the control character; it fails later in the chain (no routing
-    // headers), but must not be rejected by the firewall
+  @DisplayName("the same request without the tab is proxied through to the upstream")
+  void withoutTab_isProxiedSuccessfully() {
+    // act
     webTestClient
         .get()
-        .uri(rawUri("/proxy/b2b-assura/ci-search/v1/getItems?u_ressource_type=IPLSPortComp"))
+        .uri(rawUri(REQUEST_PATH + "?" + QUERY_PARAM + "=" + QUERY_VALUE))
+        .headers(routingHeaders())
         .exchange()
         .expectStatus()
-        .value(status -> assertThat(status).isNotEqualTo(400));
+        .isOk();
 
     // assert
+    List<LoggedRequest> recordedRequests = mockUpstream.findAll(anyRequestedFor(anyUrl()));
+    assertThat(recordedRequests).hasSize(1);
+    assertThat(recordedRequests.getFirst().queryParameter(QUERY_PARAM).firstValue())
+        .isEqualTo(QUERY_VALUE);
     assertThat(logAppender.list).isEmpty();
   }
 
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  /** Real route headers, pointed at the mock upstream's dynamically assigned port. */
+  private static Consumer<HttpHeaders> routingHeaders() {
+    return headers -> {
+      headers.setBearerAuth(TokenUtil.getConsumerAccessToken());
+      headers.set(Constants.HEADER_REMOTE_API_URL, "http://localhost:" + mockUpstream.port());
+      headers.set(Constants.HEADER_API_BASE_PATH, Config.BASE_PATH);
+      headers.set(Constants.HEADER_ENVIRONMENT, Config.ENVIRONMENT);
+      headers.set(Constants.HEADER_REALM, Config.REALM);
+      headers.set(Constants.HEADER_ACCESS_TOKEN_FORWARDING, "false");
+      headers.set(Constants.HEADER_JUMPER_CONFIG, "e30=");
+    };
+  }
+
   /**
-   * Builds an absolute URI so the percent-encoding survives verbatim; {@code uri(String)} would
-   * re-encode {@code %09} into {@code %2509}.
+   * Absolute URI so the percent-encoding survives verbatim: {@code uri(String)} would re-encode
+   * {@code %09} into {@code %2509}, and {@code uri(URI)} bypasses the configured base URL.
    */
   private URI rawUri(String pathAndQuery) {
     return URI.create("http://localhost:" + port + pathAndQuery);

--- a/src/test/java/jumper/exception/FirewallRejectionIntegrationTest.java
+++ b/src/test/java/jumper/exception/FirewallRejectionIntegrationTest.java
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.net.URI;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.micrometer.tracing.test.autoconfigure.AutoConfigureTracing;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.security.web.server.firewall.ServerExchangeRejectedHandler;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Verifies end to end that {@link LoggingServerExchangeRejectedHandler} is actually wired into the
+ * Spring Security {@code WebFilterChainProxy}.
+ *
+ * <p>The status code alone cannot prove this, since Spring Security's default handler also answers
+ * {@code 400}. The WARN log line is what distinguishes the two, so it doubles as the wiring
+ * assertion.
+ *
+ * <p>The URL under test reproduces a real production request in which a stray tab ({@code %09})
+ * prefixed a query parameter name.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {"jumper.warmup.enabled=false"})
+@ActiveProfiles("test")
+@AutoConfigureTracing
+@AutoConfigureWebTestClient(timeout = "PT10S")
+class FirewallRejectionIntegrationTest {
+
+  @Autowired WebTestClient webTestClient;
+
+  @Autowired ServerExchangeRejectedHandler rejectedHandler;
+
+  // absolute URIs are required below, since WebTestClient#uri(URI) bypasses the configured base URL
+  @Value("${local.server.port}")
+  private int port;
+
+  private ListAppender<ILoggingEvent> logAppender;
+  private ch.qos.logback.classic.Logger logger;
+
+  @BeforeEach
+  void attachAppender() {
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    logger = context.getLogger(LoggingServerExchangeRejectedHandler.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void detachAppender() {
+    logger.detachAppender(logAppender);
+    logAppender.stop();
+  }
+
+  @Test
+  @DisplayName("the custom rejection handler is the one registered in the context")
+  void customHandlerIsRegistered() {
+    assertThat(rejectedHandler).isInstanceOf(LoggingServerExchangeRejectedHandler.class);
+  }
+
+  @Test
+  @DisplayName("a tab encoded parameter name is rejected with 400 and logged at WARN")
+  void tabInParameterName_isRejectedAndLogged() {
+    // act: %09 decodes to a TAB, which is an ISO control character and therefore not an
+    // allowed parameter name for StrictServerWebExchangeFirewall
+    webTestClient
+        .get()
+        .uri(rawUri("/proxy/b2b-assura/ci-search/v1/getItems?%09u_ressource_type=IPLSPortComp"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    // assert: the WARN line proves our handler ran, not the Spring Security default
+    assertThat(logAppender.list).isNotEmpty();
+    ILoggingEvent event = logAppender.list.getFirst();
+    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+    assertThat(event.getFormattedMessage())
+        .contains("Request rejected by security firewall")
+        .contains("u_ressource_type")
+        .contains("\\u0009");
+  }
+
+  @Test
+  @DisplayName("the same URL without the tab is not rejected by the firewall")
+  void withoutTab_isNotRejectedByFirewall() {
+    // act: same request minus the control character; it fails later in the chain (no routing
+    // headers), but must not be rejected by the firewall
+    webTestClient
+        .get()
+        .uri(rawUri("/proxy/b2b-assura/ci-search/v1/getItems?u_ressource_type=IPLSPortComp"))
+        .exchange()
+        .expectStatus()
+        .value(status -> assertThat(status).isNotEqualTo(400));
+
+    // assert
+    assertThat(logAppender.list).isEmpty();
+  }
+
+  /**
+   * Builds an absolute URI so the percent-encoding survives verbatim; {@code uri(String)} would
+   * re-encode {@code %09} into {@code %2509}.
+   */
+  private URI rawUri(String pathAndQuery) {
+    return URI.create("http://localhost:" + port + pathAndQuery);
+  }
+}

--- a/src/test/java/jumper/exception/LoggingServerExchangeRejectedHandlerTest.java
+++ b/src/test/java/jumper/exception/LoggingServerExchangeRejectedHandlerTest.java
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import java.net.URI;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.observation.ServerRequestObservationContext;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.web.server.firewall.ServerExchangeRejectedException;
+
+/**
+ * Unit tests for {@link LoggingServerExchangeRejectedHandler}. These pin the observability contract
+ * that makes firewall rejections diagnosable: a WARN log line, a span event plus reason tag, the
+ * rejection recorded on the server observation, and escaping of client-controlled content.
+ */
+class LoggingServerExchangeRejectedHandlerTest {
+
+  private static final String REASON =
+      "The request was rejected because the parameter name \"\tu_ressource_type\" is not allowed.";
+
+  private Tracer tracer;
+  private Span span;
+  private ListAppender<ILoggingEvent> logAppender;
+  private ch.qos.logback.classic.Logger logger;
+
+  @BeforeEach
+  void setUp() {
+    span = mock(Span.class);
+    when(span.event(anyString())).thenReturn(span);
+    when(span.tag(anyString(), anyString())).thenReturn(span);
+
+    tracer = mock(Tracer.class);
+    when(tracer.currentSpan()).thenReturn(span);
+
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    logger = context.getLogger(LoggingServerExchangeRejectedHandler.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    logger.detachAppender(logAppender);
+    logAppender.stop();
+  }
+
+  @Test
+  @DisplayName("rejection still answers 400, matching the Spring Security default")
+  void rejection_returnsBadRequest() {
+    // arrange
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(REASON)).block();
+
+    // assert
+    assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("rejection is logged at WARN with method, path and reason")
+  void rejection_isLoggedAtWarn() {
+    // arrange
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(REASON)).block();
+
+    // assert
+    assertThat(logAppender.list).hasSize(1);
+    ILoggingEvent event = logAppender.list.getFirst();
+    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+    assertThat(event.getFormattedMessage())
+        .contains("method=GET")
+        .contains("path=/proxy/v1/getItems")
+        .contains("is not allowed");
+  }
+
+  @Test
+  @DisplayName("rejection adds an event and reason tag to the current span")
+  void rejection_recordsSpanEventAndTag() {
+    // arrange
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(REASON)).block();
+
+    // assert
+    verify(span).event(LoggingServerExchangeRejectedHandler.SPAN_EVENT);
+    verify(span)
+        .tag(LoggingServerExchangeRejectedHandler.SPAN_TAG_REASON, REASON.replace("\t", "\\u0009"));
+  }
+
+  @Test
+  @DisplayName("rejection is recorded as the error of the current server observation")
+  void rejection_setsErrorOnObservationContext() {
+    // arrange
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+    ServerRequestObservationContext observationContext =
+        new ServerRequestObservationContext(
+            exchange.getRequest(), exchange.getResponse(), exchange.getAttributes());
+    exchange
+        .getAttributes()
+        .put(
+            ServerRequestObservationContext.CURRENT_OBSERVATION_CONTEXT_ATTRIBUTE,
+            observationContext);
+    ServerExchangeRejectedException ex = new ServerExchangeRejectedException(REASON);
+
+    // act
+    handler().handle(exchange, ex).block();
+
+    // assert
+    assertThat(observationContext.getError()).isSameAs(ex);
+  }
+
+  @Test
+  @DisplayName("control characters from client input are escaped to prevent log forging")
+  void rejection_escapesControlCharacters() {
+    // arrange: a %0a encoded parameter name yields a raw newline inside the reason
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+    String forging = "The request was rejected because the parameter name \"\nu\" is not allowed.";
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(forging)).block();
+
+    // assert
+    String logged = logAppender.list.getFirst().getFormattedMessage();
+    assertThat(logged).doesNotContain("\n").contains("\\u000a");
+  }
+
+  @Test
+  @DisplayName("no span bound to the request does not break rejection handling")
+  void rejection_withoutCurrentSpan_doesNotFail() {
+    // arrange
+    when(tracer.currentSpan()).thenReturn(null);
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(REASON)).block();
+
+    // assert
+    assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(logAppender.list).hasSize(1);
+    verify(span, never()).event(anyString());
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  private LoggingServerExchangeRejectedHandler handler() {
+    return new LoggingServerExchangeRejectedHandler(tracer);
+  }
+
+  private static MockServerWebExchange exchange(String path) {
+    return MockServerWebExchange.from(
+        MockServerHttpRequest.method(HttpMethod.GET, URI.create(path)).build());
+  }
+}

--- a/src/test/java/jumper/exception/LoggingServerExchangeRejectedHandlerTest.java
+++ b/src/test/java/jumper/exception/LoggingServerExchangeRejectedHandlerTest.java
@@ -6,6 +6,7 @@ package jumper.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -33,7 +35,8 @@ import org.springframework.security.web.server.firewall.ServerExchangeRejectedEx
 /**
  * Unit tests for {@link LoggingServerExchangeRejectedHandler}. These pin the observability contract
  * that makes firewall rejections diagnosable: a WARN log line, a span event plus reason tag, the
- * rejection recorded on the server observation, and escaping of client-controlled content.
+ * rejection recorded on the server observation, and the truncation plus escaping of
+ * client-controlled content.
  */
 class LoggingServerExchangeRejectedHandlerTest {
 
@@ -167,9 +170,84 @@ class LoggingServerExchangeRejectedHandlerTest {
     verify(span, never()).event(anyString());
   }
 
+  @Test
+  @DisplayName("an oversized client controlled reason is truncated in the log and the span tag")
+  void rejection_truncatesOversizedReason() {
+    // arrange: the firewall embeds header values verbatim and Netty accepts up to 8 KB of them
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+    String oversized = "x".repeat(8 * 1024);
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(oversized)).block();
+
+    // assert
+    String expected =
+        "x".repeat(LoggingServerExchangeRejectedHandler.MAX_VALUE_LENGTH)
+            + LoggingServerExchangeRejectedHandler.TRUNCATION_MARKER;
+    assertThat(logAppender.list.getFirst().getFormattedMessage()).contains(expected);
+    verify(span).tag(LoggingServerExchangeRejectedHandler.SPAN_TAG_REASON, expected);
+  }
+
+  @Test
+  @DisplayName("a reason at the truncation limit is left untouched")
+  void rejection_atLimit_isNotTruncated() {
+    // arrange
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+    String atLimit = "x".repeat(LoggingServerExchangeRejectedHandler.MAX_VALUE_LENGTH);
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(atLimit)).block();
+
+    // assert
+    verify(span).tag(LoggingServerExchangeRejectedHandler.SPAN_TAG_REASON, atLimit);
+    assertThat(logAppender.list.getFirst().getFormattedMessage())
+        .doesNotContain(LoggingServerExchangeRejectedHandler.TRUNCATION_MARKER);
+  }
+
+  @Test
+  @DisplayName("characters outside the BMP survive escaping intact")
+  void rejection_keepsSupplementaryCharacters() {
+    // arrange: U+1F600 is a surrogate pair and must not be mangled by the char wise escaping
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+    String withEmoji = "parameter name \"\uD83D\uDE00\" is not allowed.";
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(withEmoji)).block();
+
+    // assert
+    verify(span).tag(LoggingServerExchangeRejectedHandler.SPAN_TAG_REASON, withEmoji);
+  }
+
+  @Test
+  @DisplayName("truncation never leaves a dangling high surrogate behind")
+  void rejection_truncation_doesNotSplitSurrogatePair() {
+    // arrange: the cut falls exactly between the two halves of the pair
+    MockServerWebExchange exchange = exchange("/proxy/v1/getItems");
+    String reason =
+        "x".repeat(LoggingServerExchangeRejectedHandler.MAX_VALUE_LENGTH - 1) + "\uD83D\uDE00";
+
+    // act
+    handler().handle(exchange, new ServerExchangeRejectedException(reason)).block();
+
+    // assert
+    String tagged = capturedTag();
+    assertThat(tagged)
+        .isEqualTo(
+            "x".repeat(LoggingServerExchangeRejectedHandler.MAX_VALUE_LENGTH - 1)
+                + LoggingServerExchangeRejectedHandler.TRUNCATION_MARKER);
+    assertThat(tagged.chars().anyMatch(character -> Character.isSurrogate((char) character)))
+        .isFalse();
+  }
+
   // ---------------------------------------------------------------------------
   // helpers
   // ---------------------------------------------------------------------------
+
+  private String capturedTag() {
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(span).tag(eq(LoggingServerExchangeRejectedHandler.SPAN_TAG_REASON), captor.capture());
+    return captor.getValue();
+  }
 
   private LoggingServerExchangeRejectedHandler handler() {
     return new LoggingServerExchangeRejectedHandler(tracer);


### PR DESCRIPTION
StrictServerWebExchangeFirewall rejections were answered with 400 by Spring Security's HttpStatusExchangeRejectedHandler, which only logs at DEBUG and writes the status directly onto the response. It never throws, so JsonErrorWebExceptionHandler was bypassed and no error span was produced. At the default INFO level such a request was indistinguishable from a silent 400: the server span was recorded, but there was no log line, no error tag and no outgoing request span.

Add LoggingServerExchangeRejectedHandler, registered as a ServerExchangeRejectedHandler bean and picked up by WebFluxSecurityConfiguration. It delegates for the status code, so the 400 response contract is unchanged, and additionally:

- logs at WARN with request method, path and rejection reason
- records a firewall.rejected span event plus a rejection reason tag
- marks the current server observation as errored, independently of thread-bound tracing state

The rejection reason embeds the offending client-controlled value verbatim and may contain control characters (for example a raw newline for a %0a encoded parameter name), so all logged and tagged values are escaped to prevent log forging.