### PR TITLE
test(jumper): add tests for verifying enabled/disabled Netty header validation for upstream client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,44 @@ SPDX-License-Identifier: Apache-2.0
         <configuration>
           <excludedGroups>ignore</excludedGroups>
           <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
+          <!-- The suite is split into two executions below. Running -Dtest=SomeClass only
+               matches one of them, so the other must not fail the build for having no match. -->
+          <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
         </configuration>
+        <executions>
+          <!-- Main run: every test shares a single reused JVM (fast; keeps the Spring
+               context cache warm across classes). The two Netty RFC 9112 flag tests are
+               excluded here and handled by the isolated execution below. -->
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>**/UpstreamHeaderValidationEnabledIntegrationTest.java</exclude>
+                <exclude>**/UpstreamHeaderValidationDisabledIntegrationTest.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <!-- Netty reads io.netty.handler.codec.http.rfc9112TransferEncoding once per JVM at
+               HttpObjectDecoder class-load. These two tests need opposite values of that flag,
+               so reuseForks=false gives each class its own JVM, isolated from the rest of the
+               suite (which keeps JVM reuse). -->
+          <execution>
+            <id>netty-rfc9112-isolated</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <reuseForks>false</reuseForks>
+              <includes>
+                <include>**/UpstreamHeaderValidationEnabledIntegrationTest.java</include>
+                <include>**/UpstreamHeaderValidationDisabledIntegrationTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.google.cloud.tools</groupId>

--- a/src/test/java/jumper/mocks/RawHttpUpstream.java
+++ b/src/test/java/jumper/mocks/RawHttpUpstream.java
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.mocks;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A minimal HTTP upstream that writes a caller-supplied response byte-for-byte onto the socket.
+ *
+ * <p>Unlike WireMock/Jetty (or any conformant HTTP server), this mock performs <b>no</b> framing
+ * normalisation: it never reconciles {@code Content-Length} against {@code Transfer-Encoding},
+ * never rewrites headers, and never validates the response. That makes it the only reliable way to
+ * put deliberately malformed or ambiguous responses (e.g. conflicting {@code Transfer-Encoding} +
+ * {@code Content-Length} framing, used for request-smuggling tests) on the wire so a client decoder
+ * actually has to deal with them.
+ *
+ * <p>The same response is served to every connection until {@link #close()} is called. Typical use:
+ *
+ * <pre>{@code
+ * try (RawHttpUpstream upstream = RawHttpUpstream.serving(response).start()) {
+ *   String url = upstream.baseUrl();
+ *   // ... point the client under test at url ...
+ * }
+ * }</pre>
+ */
+public class RawHttpUpstream implements AutoCloseable {
+
+  private final byte[] rawResponse;
+  private ServerSocket serverSocket;
+  private Thread acceptThread;
+  private volatile boolean running;
+
+  private RawHttpUpstream(byte[] rawResponse) {
+    this.rawResponse = rawResponse;
+  }
+
+  /**
+   * Creates an upstream that will emit {@code rawResponse} verbatim (encoded as ISO-8859-1, i.e.
+   * one byte per char, so status line, headers and body are sent exactly as written).
+   */
+  public static RawHttpUpstream serving(String rawResponse) {
+    return new RawHttpUpstream(rawResponse.getBytes(StandardCharsets.ISO_8859_1));
+  }
+
+  /**
+   * Builds an HTTP/1.1 200 response carrying <b>both</b> {@code Transfer-Encoding: chunked} and
+   * {@code Content-Length}, which is the malformed framing forbidden by RFC 9112 §6.1 and rejected
+   * by strict decoders (Netty 4.2 with {@code useRfc9112TransferEncoding=true}).
+   */
+  public static RawHttpUpstream servingConflictingFramingHeaders(String jsonBody) {
+    String chunkedBody =
+        Integer.toHexString(jsonBody.getBytes(StandardCharsets.UTF_8).length)
+            + "\r\n"
+            + jsonBody
+            + "\r\n0\r\n\r\n";
+    String response =
+        "HTTP/1.1 200 OK\r\n"
+            + "Content-Type: application/json\r\n"
+            + "Transfer-Encoding: chunked\r\n"
+            + "Content-Length: "
+            + jsonBody.getBytes(StandardCharsets.UTF_8).length
+            + "\r\n"
+            + "\r\n"
+            + chunkedBody;
+    return serving(response);
+  }
+
+  /** Binds to an ephemeral port and starts serving in a daemon thread. */
+  public RawHttpUpstream start() throws IOException {
+    serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+    running = true;
+    acceptThread = new Thread(this::serveLoop, "raw-http-upstream");
+    acceptThread.setDaemon(true);
+    acceptThread.start();
+    return this;
+  }
+
+  public int getPort() {
+    return serverSocket.getLocalPort();
+  }
+
+  public String baseUrl() {
+    return "http://localhost:" + getPort();
+  }
+
+  private void serveLoop() {
+    while (running && !serverSocket.isClosed()) {
+      try (Socket connection = serverSocket.accept()) {
+        drainRequestHeaders(connection.getInputStream());
+        OutputStream out = connection.getOutputStream();
+        out.write(rawResponse);
+        out.flush();
+      } catch (IOException e) {
+        // Expected on shutdown (socket closed) or when the client resets after rejecting the
+        // malformed response. Nothing actionable in a test double.
+      }
+    }
+  }
+
+  /** Consumes the request head up to and including the terminating CRLF CRLF. */
+  private static void drainRequestHeaders(InputStream in) throws IOException {
+    int state = 0; // progress through \r \n \r \n
+    int b;
+    while ((b = in.read()) != -1) {
+      switch (state) {
+        case 0 -> state = (b == '\r') ? 1 : 0;
+        case 1 -> state = (b == '\n') ? 2 : 0;
+        case 2 -> state = (b == '\r') ? 3 : 0;
+        case 3 -> {
+          if (b == '\n') {
+            return;
+          }
+          state = 0;
+        }
+        default -> state = 0;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    running = false;
+    if (serverSocket != null) {
+      serverSocket.close();
+    }
+    if (acceptThread != null) {
+      acceptThread.interrupt();
+    }
+  }
+}

--- a/src/test/java/jumper/service/UpstreamHeaderValidationDisabledIntegrationTest.java
+++ b/src/test/java/jumper/service/UpstreamHeaderValidationDisabledIntegrationTest.java
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import jumper.Constants;
+import jumper.mocks.RawHttpUpstream;
+import jumper.model.config.JumperConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient(timeout = "PT10S")
+class UpstreamHeaderValidationDisabledIntegrationTest {
+
+  // Netty reads io.netty.handler.codec.http.rfc9112TransferEncoding once, when HttpObjectDecoder is
+  // class-loaded during context refresh. Setting it here (in a static initialiser, before the
+  // Spring context and therefore Netty are initialised) makes the decoder tolerate the conflicting
+  // framing — the same effect production gets from jumper.http.rfc9112-transfer-encoding=false via
+  // NettyRfc9112EnvironmentPostProcessor. Surefire runs this class in its own JVM
+  // (reuseForks=false), so the property does not leak into other tests.
+  static {
+    System.setProperty("io.netty.handler.codec.http.rfc9112TransferEncoding", "false");
+  }
+
+  // WireMock/Jetty normalises outgoing framing headers and would silently drop the conflicting
+  // Content-Length, so it can never emit a genuine Transfer-Encoding + Content-Length response.
+  // RawHttpUpstream writes the malformed bytes verbatim so Netty's decoder actually sees them.
+  static RawHttpUpstream upstream;
+
+  @Autowired WebTestClient webTestClient;
+
+  @BeforeAll
+  static void startUpstream() throws IOException {
+    upstream = RawHttpUpstream.servingConflictingFramingHeaders("{\"state\":\"ok\"}").start();
+  }
+
+  @AfterAll
+  static void stopUpstream() throws IOException {
+    System.clearProperty("io.netty.handler.codec.http.rfc9112TransferEncoding");
+    if (upstream != null) {
+      upstream.close();
+    }
+  }
+
+  @Test
+  void acceptUpstreamResponseWithConflictingFramingHeaders() {
+    String remoteApiUrl = upstream.baseUrl();
+
+    JumperConfig jc = new JumperConfig();
+    jc.setRemoteApiUrl(remoteApiUrl);
+    jc.setApiBasePath("/");
+    jc.setRealmName(Constants.DEFAULT_REALM);
+    jc.setEnvName("warmup");
+    String jumperConfigBase64 = JumperConfig.toJsonBase64(jc);
+
+    EntityExchangeResult<String> result =
+        webTestClient
+            .get()
+            .uri(Constants.PROXY_ROOT_PATH_PREFIX + "/warmup")
+            .header(Constants.HEADER_JUMPER_CONFIG, jumperConfigBase64)
+            .header(
+                Constants.HEADER_AUTHORIZATION,
+                "Bearer " + jumper.util.TokenUtil.getConsumerAccessToken())
+            .header(Constants.HEADER_REMOTE_API_URL, remoteApiUrl)
+            .header(Constants.HEADER_API_BASE_PATH, "/")
+            .header(Constants.HEADER_REALM, Constants.DEFAULT_REALM)
+            .header(Constants.HEADER_ENVIRONMENT, "warmup")
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult();
+
+    assertThat(result.getResponseBody()).contains("state");
+  }
+}

--- a/src/test/java/jumper/service/UpstreamHeaderValidationEnabledIntegrationTest.java
+++ b/src/test/java/jumper/service/UpstreamHeaderValidationEnabledIntegrationTest.java
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import jumper.Constants;
+import jumper.mocks.RawHttpUpstream;
+import jumper.model.config.JumperConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient(timeout = "PT10S")
+class UpstreamHeaderValidationEnabledIntegrationTest {
+
+  // Netty reads io.netty.handler.codec.http.rfc9112TransferEncoding once, when HttpObjectDecoder is
+  // class-loaded during context refresh. Pin it to the strict default here (before the Spring
+  // context and therefore Netty are initialised) so the test does not depend on the ambient
+  // default — the same value production gets from jumper.http.rfc9112-transfer-encoding=true via
+  // NettyRfc9112EnvironmentPostProcessor. Surefire runs this class in its own JVM
+  // (reuseForks=false), so the property does not leak into other tests.
+  static {
+    System.setProperty("io.netty.handler.codec.http.rfc9112TransferEncoding", "true");
+  }
+
+  // WireMock/Jetty normalises outgoing framing headers and would silently drop the conflicting
+  // Content-Length, so it can never emit a genuine Transfer-Encoding + Content-Length response.
+  // RawHttpUpstream writes the malformed bytes verbatim so Netty's decoder actually sees them.
+  static RawHttpUpstream upstream;
+
+  @Autowired WebTestClient webTestClient;
+
+  @BeforeAll
+  static void startUpstream() throws IOException {
+    upstream = RawHttpUpstream.servingConflictingFramingHeaders("{\"state\":\"ok\"}").start();
+  }
+
+  @AfterAll
+  static void stopUpstream() throws IOException {
+    System.clearProperty("io.netty.handler.codec.http.rfc9112TransferEncoding");
+    if (upstream != null) {
+      upstream.close();
+    }
+  }
+
+  @Test
+  void rejectsUpstreamResponseWithConflictingFramingHeaders() {
+    String remoteApiUrl = upstream.baseUrl();
+
+    JumperConfig jc = new JumperConfig();
+    jc.setRemoteApiUrl(remoteApiUrl);
+    jc.setApiBasePath("/");
+    jc.setRealmName(Constants.DEFAULT_REALM);
+    String jumperConfigBase64 = JumperConfig.toJsonBase64(jc);
+
+    EntityExchangeResult<String> result =
+        webTestClient
+            .get()
+            .uri(Constants.PROXY_ROOT_PATH_PREFIX + "/warmup")
+            .header(Constants.HEADER_JUMPER_CONFIG, jumperConfigBase64)
+            .header(
+                Constants.HEADER_AUTHORIZATION,
+                "Bearer " + jumper.util.TokenUtil.getConsumerAccessToken())
+            .header(Constants.HEADER_REMOTE_API_URL, remoteApiUrl)
+            .header(Constants.HEADER_API_BASE_PATH, "/")
+            .header(Constants.HEADER_REALM, Constants.DEFAULT_REALM)
+            .exchange()
+            .expectBody(String.class)
+            .returnResult();
+
+    // Netty 4.2 defaults useRfc9112TransferEncoding=true: a response carrying both
+    // Transfer-Encoding and Content-Length throws ContentLengthNotAllowedException in the response
+    // decoder (RFC 9112 §6.1 request-smuggling defence). Jumper surfaces that as a 5xx.
+    int status = result.getStatus().value();
+    assertThat(status)
+        .withFailMessage(
+            "Expected a 5xx rejection of the malformed upstream framing, got %s", status)
+        .isGreaterThanOrEqualTo(500);
+  }
+}


### PR DESCRIPTION
… upstream client