### PR TITLE
fix(spectre): resolve realm on the routing_config path and isolate event failures

### DIFF
--- a/src/main/java/jumper/Constants.java
+++ b/src/main/java/jumper/Constants.java
@@ -70,6 +70,7 @@ public class Constants {
   public static final String ISSUER_SUFFIX = "/protocol/openid-connect/token";
   public static final String LOCALHOST_ISSUER_SERVICE = "http://localhost:8081/api/v1";
   public static final String DEFAULT_REALM = "default";
+  public static final String REALMS_PATH_SEGMENT = "realms/";
   public static final String BEARER = "Bearer";
   public static final String BASIC = "Basic";
 

--- a/src/main/java/jumper/filter/SpectreRequestFilter.java
+++ b/src/main/java/jumper/filter/SpectreRequestFilter.java
@@ -4,6 +4,7 @@
 
 package jumper.filter;
 
+import java.util.Objects;
 import jumper.model.config.JumperConfig;
 import jumper.model.config.RouteListener;
 import jumper.service.SpectreService;
@@ -43,7 +44,7 @@ public class SpectreRequestFilter
               requestBody);
 
           JumperConfig jc = ExchangeStateManager.getJumperConfig(exchange).orElse(null);
-          if (!jc.isListenerMatched()) {
+          if (Objects.isNull(jc) || !jc.isListenerMatched()) {
             return chain.filter(exchange.mutate().request(request).build());
           }
 

--- a/src/main/java/jumper/filter/SpectreResponseFilter.java
+++ b/src/main/java/jumper/filter/SpectreResponseFilter.java
@@ -59,7 +59,7 @@ public class SpectreResponseFilter
                           // use jumperConfig passed with exchange
                           JumperConfig jumperConfig =
                               ExchangeStateManager.getJumperConfig(exchange).orElse(null);
-                          if (jumperConfig.isListenerMatched()) {
+                          if (Objects.nonNull(jumperConfig) && jumperConfig.isListenerMatched()) {
                             RouteListener listener =
                                 jumperConfig.getRouteListener().get(jumperConfig.getConsumer());
                             // Fire-and-forget: publish event asynchronously without blocking the

--- a/src/main/java/jumper/model/config/JumperConfig.java
+++ b/src/main/java/jumper/model/config/JumperConfig.java
@@ -188,6 +188,8 @@ public class JumperConfig {
     this.setRouteListener(jc.getRouteListener());
     this.setGatewayClient(jc.getGatewayClient());
 
+    resolveMissingRealmName(request);
+
     // check loadBalancing
     if (Objects.nonNull(loadBalancing) && !loadBalancing.getServers().isEmpty()) {
       setRemoteApiUrl(LoadBalancingUtil.calculateUpstream(loadBalancing.getServers()));
@@ -218,6 +220,52 @@ public class JumperConfig {
         request); // TODO: remove as soon we have completely shifted to json_config
 
     return jc;
+  }
+
+  /**
+   * Fills in the realm for configs assembled from {@code routing_config}, the path taken whenever
+   * zone failover is configured. The realm can be absent there: the control plane emits the {@code
+   * realm} header only for non-failover routes, and a per-entry {@code realm} is omitted when
+   * empty. Without a realm, {@code SpectreService} builds its publish URL from {@code null} and the
+   * request it was only observing fails.
+   *
+   * <p>Deliberately additive: a realm already present in the config blob is never overwritten, so
+   * the legacy-header path in {@link #fillWithLegacyHeaders(ServerHttpRequest)} keeps its existing
+   * precedence and an entry keeps the realm the control plane assigned it.
+   */
+  private void resolveMissingRealmName(ServerHttpRequest request) {
+    if (StringUtils.isNotBlank(realmName)) {
+      return;
+    }
+
+    setRealmName(
+        determineRealmName(
+            HeaderUtil.getLastValueFromHeaderField(request, Constants.HEADER_REALM)));
+  }
+
+  /**
+   * Realm precedence for a config that carries none of its own: the legacy {@code realm} header,
+   * then the realm embedded in an issuer URL, then {@link Constants#DEFAULT_REALM}.
+   *
+   * <p>Package-private for testing.
+   */
+  String determineRealmName(String realmHeader) {
+    if (StringUtils.isNotBlank(realmHeader)) {
+      return realmHeader;
+    }
+
+    // The gateway client issuer is this gateway's own issuer, ".../realms/<realm>". Preferred over
+    // the mesh issuer below, which names the *target* zone and only agrees while realms match.
+    String issuer = Objects.nonNull(gatewayClient) ? gatewayClient.getIssuer() : null;
+    if (StringUtils.isBlank(issuer)) {
+      issuer = internalTokenEndpoint;
+    }
+    if (StringUtils.isNotBlank(issuer) && issuer.contains(Constants.REALMS_PATH_SEGMENT)) {
+      return issuer.replaceFirst(".*" + Constants.REALMS_PATH_SEGMENT, "");
+    }
+
+    log.warn("no realm resolvable for config entry, falling back to {}", Constants.DEFAULT_REALM);
+    return Constants.DEFAULT_REALM;
   }
 
   public boolean isListenerMatched() {

--- a/src/main/java/jumper/model/config/JumperConfig.java
+++ b/src/main/java/jumper/model/config/JumperConfig.java
@@ -188,7 +188,7 @@ public class JumperConfig {
     this.setRouteListener(jc.getRouteListener());
     this.setGatewayClient(jc.getGatewayClient());
 
-    resolveMissingRealmName(request);
+    resolveMissingRealmName();
 
     // check loadBalancing
     if (Objects.nonNull(loadBalancing) && !loadBalancing.getServers().isEmpty()) {
@@ -233,38 +233,42 @@ public class JumperConfig {
    * the legacy-header path in {@link #fillWithLegacyHeaders(ServerHttpRequest)} keeps its existing
    * precedence and an entry keeps the realm the control plane assigned it.
    */
-  private void resolveMissingRealmName(ServerHttpRequest request) {
+  private void resolveMissingRealmName() {
     if (StringUtils.isNotBlank(realmName)) {
       return;
     }
 
-    setRealmName(
-        determineRealmName(
-            HeaderUtil.getLastValueFromHeaderField(request, Constants.HEADER_REALM)));
+    setRealmName(determineRealmName());
   }
 
   /**
-   * Realm precedence for a config that carries none of its own: the legacy {@code realm} header,
-   * then the realm embedded in an issuer URL, then {@link Constants#DEFAULT_REALM}.
+   * Realm for a {@code routing_config} entry that carries none of its own: the realm embedded in
+   * the entry's own issuer, else {@link Constants#DEFAULT_REALM}.
+   *
+   * <p>Both sources are the routing_config blob itself, and that is deliberate - the realm selects
+   * the Horizon destination and the issuer of gateway-signed tokens, so it must not be sourced from
+   * a channel the caller can write. Two channels are excluded for that reason:
+   *
+   * <ul>
+   *   <li>the inbound {@code realm} header - the control plane's last-mile-security feature is the
+   *       only thing that adds or replaces it, and that feature is skipped for failover routes, so
+   *       on this path a caller-supplied header arrives unsanitised;
+   *   <li>{@code gatewayClient.issuer} - {@code gatewayClient} comes from the {@code jumper_config}
+   *       header, which the control plane emits <em>instead of</em> {@code routing_config} and
+   *       never alongside it, so on this path its only producer is the caller.
+   * </ul>
    *
    * <p>Package-private for testing.
    */
-  String determineRealmName(String realmHeader) {
-    if (StringUtils.isNotBlank(realmHeader)) {
-      return realmHeader;
+  String determineRealmName() {
+    if (StringUtils.isNotBlank(internalTokenEndpoint)
+        && internalTokenEndpoint.contains(Constants.REALMS_PATH_SEGMENT)) {
+      return internalTokenEndpoint.replaceFirst(".*" + Constants.REALMS_PATH_SEGMENT, "");
     }
 
-    // The gateway client issuer is this gateway's own issuer, ".../realms/<realm>". Preferred over
-    // the mesh issuer below, which names the *target* zone and only agrees while realms match.
-    String issuer = Objects.nonNull(gatewayClient) ? gatewayClient.getIssuer() : null;
-    if (StringUtils.isBlank(issuer)) {
-      issuer = internalTokenEndpoint;
-    }
-    if (StringUtils.isNotBlank(issuer) && issuer.contains(Constants.REALMS_PATH_SEGMENT)) {
-      return issuer.replaceFirst(".*" + Constants.REALMS_PATH_SEGMENT, "");
-    }
-
-    log.warn("no realm resolvable for config entry, falling back to {}", Constants.DEFAULT_REALM);
+    log.warn(
+        "no realm resolvable for routing_config entry, falling back to {}",
+        Constants.DEFAULT_REALM);
     return Constants.DEFAULT_REALM;
   }
 

--- a/src/main/java/jumper/service/SpectreService.java
+++ b/src/main/java/jumper/service/SpectreService.java
@@ -66,7 +66,15 @@ public class SpectreService {
       Object http,
       RouteListener listener,
       String payload) {
-    return publishEvent(createEvent(jc, exchange, http, listener, payload), jc);
+    // Deferred so that failures while *building* the event or the publish URL surface as an error
+    // signal instead of being thrown into the gateway filter chain, which would fail the request
+    // this event merely observes.
+    return Mono.defer(() -> publishEvent(createEvent(jc, exchange, http, listener, payload), jc))
+        .onErrorResume(
+            throwable -> {
+              log.error("Error publishing Spectre event", throwable);
+              return Mono.empty(); // Don't fail the main request flow
+            });
   }
 
   private Spectre createEvent(
@@ -137,15 +145,10 @@ public class SpectreService {
     String envName = jc.getRealmName();
 
     return publishEventMono(
-            publishEventUrl.replaceFirst(Constants.ENVIRONMENT_PLACEHOLDER, envName),
-            tokenGeneratorService.generateGatewayTokenForPublisher(
-                localIssuerUrl + "/" + envName, envName),
-            event)
-        .onErrorResume(
-            throwable -> {
-              log.error("Error publishing Spectre event", throwable);
-              return Mono.empty(); // Don't fail the main request flow
-            });
+        publishEventUrl.replaceFirst(Constants.ENVIRONMENT_PLACEHOLDER, envName),
+        tokenGeneratorService.generateGatewayTokenForPublisher(
+            localIssuerUrl + "/" + envName, envName),
+        event);
   }
 
   private Mono<Void> publishEventMono(String url, String token, Spectre event) {

--- a/src/main/java/jumper/service/SpectreService.java
+++ b/src/main/java/jumper/service/SpectreService.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.regex.Matcher;
 import jumper.Constants;
 import jumper.config.SpectreConfiguration;
 import jumper.model.config.JumperConfig;
@@ -145,7 +146,10 @@ public class SpectreService {
     String envName = jc.getRealmName();
 
     return publishEventMono(
-        publishEventUrl.replaceFirst(Constants.ENVIRONMENT_PLACEHOLDER, envName),
+        // quoted: the realm is config-supplied, and an unescaped "$" or "\" in a replacement
+        // string is interpreted by the regex engine instead of inserted literally
+        publishEventUrl.replaceFirst(
+            Constants.ENVIRONMENT_PLACEHOLDER, Matcher.quoteReplacement(envName)),
         tokenGeneratorService.generateGatewayTokenForPublisher(
             localIssuerUrl + "/" + envName, envName),
         event);

--- a/src/test/java/jumper/HeaderSteps.java
+++ b/src/test/java/jumper/HeaderSteps.java
@@ -97,6 +97,12 @@ public class HeaderSteps {
         RoutingConfigUtil.getSecondaryRouteHeadersWithLoadbalancing(baseSteps));
   }
 
+  @Given("Listener routing_config header set")
+  public void listenerRoutingConfigHeaderSet() {
+    baseSteps.authHeader = TokenUtil.getConsumerAccessToken();
+    baseSteps.setHttpHeadersOfRequest(RoutingConfigUtil.getListenerRouteHeaders(baseSteps));
+  }
+
   @Given("Proxy routing_config header set")
   public void proxyRoutingConfigHeaderSet() {
     baseSteps.authHeader = TokenUtil.getConsumerAccessToken();

--- a/src/test/java/jumper/model/config/JumperConfigTest.java
+++ b/src/test/java/jumper/model/config/JumperConfigTest.java
@@ -53,6 +53,62 @@ class JumperConfigTest {
     return oc;
   }
 
+  private JumperConfig configWithGatewayClientIssuer(String issuer) {
+    GatewayClient gatewayClient = new GatewayClient();
+    gatewayClient.setIssuer(issuer);
+    JumperConfig jc = new JumperConfig();
+    jc.setGatewayClient(gatewayClient);
+    return jc;
+  }
+
+  @Test
+  void determineRealmName_prefersRealmHeader() {
+    // arrange
+    JumperConfig jc = configWithGatewayClientIssuer("https://issuer/auth/realms/from-issuer");
+
+    // act & assert
+    assertEquals("from-header", jc.determineRealmName("from-header"));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", " "})
+  void determineRealmName_derivesRealmFromGatewayClientIssuerWhenHeaderIsBlank(String realmHeader) {
+    // arrange
+    JumperConfig jc = configWithGatewayClientIssuer("https://issuer/auth/realms/from-issuer");
+
+    // act & assert
+    assertEquals("from-issuer", jc.determineRealmName(realmHeader));
+  }
+
+  @Test
+  void determineRealmName_derivesRealmFromMeshIssuerWhenNoGatewayClientExists() {
+    // arrange - a zoned routing_config entry: mesh issuer, no realm, no gateway client
+    JumperConfig jc = new JumperConfig();
+    jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/from-mesh-issuer");
+
+    // act & assert
+    assertEquals("from-mesh-issuer", jc.determineRealmName(null));
+  }
+
+  @Test
+  void determineRealmName_fallsBackToDefaultRealmWhenNoSourceIsAvailable() {
+    // arrange
+    JumperConfig jc = new JumperConfig();
+
+    // act & assert
+    assertEquals(Constants.DEFAULT_REALM, jc.determineRealmName(null));
+  }
+
+  @Test
+  void determineRealmName_fallsBackToDefaultRealmWhenIssuerCarriesNoRealmSegment() {
+    // arrange
+    JumperConfig jc = configWithGatewayClientIssuer("https://issuer/auth/no-realm-here");
+
+    // act & assert
+    assertEquals(Constants.DEFAULT_REALM, jc.determineRealmName(null));
+  }
+
   @Test
   void getOauthCredentials_emptyWhenNoOauthConfigured() {
     // arrange

--- a/src/test/java/jumper/model/config/JumperConfigTest.java
+++ b/src/test/java/jumper/model/config/JumperConfigTest.java
@@ -9,12 +9,26 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.HashMap;
 import java.util.Optional;
 import jumper.Constants;
+import jumper.util.ObjectMapperUtil;
+import jumper.util.TokenUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import tools.jackson.databind.json.JsonMapper;
 
 class JumperConfigTest {
+
+  @BeforeAll
+  static void initObjectMapper() {
+    // fillProcessingInfo parses the jumper_config header and the JWT header via ObjectMapperUtil,
+    // whose static holder is normally populated by Spring. Populate it for this context-less test.
+    new ObjectMapperUtil(JsonMapper.builder().build());
+  }
 
   private static final String CONSUMER = "eni--local-team--local-app";
   private static final String CONSUMER_SCOPE = "consumer_scope";
@@ -53,60 +67,130 @@ class JumperConfigTest {
     return oc;
   }
 
-  private JumperConfig configWithGatewayClientIssuer(String issuer) {
+  private static final String ENTRY_REALM = "entry-realm";
+  private static final String HEADER_REALM = "header-realm";
+  private static final String MESH_REALM = "mesh-realm";
+  private static final String GATEWAY_CLIENT_REALM = "gateway-client-realm";
+
+  private static JumperConfig configWithMeshIssuer(String realm) {
+    JumperConfig jc = new JumperConfig();
+    jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/" + realm);
+    return jc;
+  }
+
+  private static JumperConfig configWithGatewayClientIssuer(String realm) {
     GatewayClient gatewayClient = new GatewayClient();
-    gatewayClient.setIssuer(issuer);
+    gatewayClient.setIssuer("http://localhost:1081/auth/realms/" + realm);
     JumperConfig jc = new JumperConfig();
     jc.setGatewayClient(gatewayClient);
     return jc;
   }
 
-  @Test
-  void determineRealmName_prefersRealmHeader() {
-    // arrange
-    JumperConfig jc = configWithGatewayClientIssuer("https://issuer/auth/realms/from-issuer");
-
-    // act & assert
-    assertEquals("from-header", jc.determineRealmName("from-header"));
+  /**
+   * A jumper_config header value carrying a gateway client, as the legacy control plane sends it.
+   */
+  private static String jumperConfigHeaderWithGatewayClientIssuer(String realm) {
+    return JumperConfig.toJsonBase64(configWithGatewayClientIssuer(realm));
   }
 
-  @ParameterizedTest
-  @NullSource
-  @ValueSource(strings = {"", " "})
-  void determineRealmName_derivesRealmFromGatewayClientIssuerWhenHeaderIsBlank(String realmHeader) {
-    // arrange
-    JumperConfig jc = configWithGatewayClientIssuer("https://issuer/auth/realms/from-issuer");
+  private static ServerHttpRequest requestWith(String realmHeader, String jumperConfigHeader) {
+    MockServerHttpRequest.BodyBuilder builder =
+        MockServerHttpRequest.method(HttpMethod.DELETE, "/listener/services/1")
+            .header(Constants.HEADER_AUTHORIZATION, "Bearer " + TokenUtil.getConsumerAccessToken());
+    if (realmHeader != null) {
+      builder.header(Constants.HEADER_REALM, realmHeader);
+    }
+    if (jumperConfigHeader != null) {
+      builder.header(Constants.HEADER_JUMPER_CONFIG, jumperConfigHeader);
+    }
+    return builder.build();
+  }
 
-    // act & assert
-    assertEquals("from-issuer", jc.determineRealmName(realmHeader));
+  private static JumperConfig routingConfigEntry(String entryRealm, String meshRealm) {
+    JumperConfig jc = meshRealm == null ? new JumperConfig() : configWithMeshIssuer(meshRealm);
+    jc.setRealmName(entryRealm);
+    // fillProcessingInfo requires routing information or it throws
+    jc.setRemoteApiUrl("http://localhost:1080/provider");
+    return jc;
   }
 
   @Test
-  void determineRealmName_derivesRealmFromMeshIssuerWhenNoGatewayClientExists() {
-    // arrange - a zoned routing_config entry: mesh issuer, no realm, no gateway client
+  void determineRealmName_derivesRealmFromTheEntryIssuer() {
+    // arrange
+    JumperConfig jc = configWithMeshIssuer(MESH_REALM);
+
+    // act & assert
+    assertEquals(MESH_REALM, jc.determineRealmName());
+  }
+
+  @Test
+  void determineRealmName_ignoresGatewayClientIssuer() {
+    // arrange: gatewayClient comes from the jumper_config header, which the control plane does not
+    // emit alongside routing_config - on this path only the caller can supply it
+    JumperConfig jc = configWithGatewayClientIssuer(GATEWAY_CLIENT_REALM);
+
+    // act & assert
+    assertEquals(Constants.DEFAULT_REALM, jc.determineRealmName());
+  }
+
+  @Test
+  void determineRealmName_fallsBackToDefaultRealmWhenNoIssuerExists() {
+    // arrange
     JumperConfig jc = new JumperConfig();
-    jc.setInternalTokenEndpoint("http://localhost:1081/auth/realms/from-mesh-issuer");
 
     // act & assert
-    assertEquals("from-mesh-issuer", jc.determineRealmName(null));
-  }
-
-  @Test
-  void determineRealmName_fallsBackToDefaultRealmWhenNoSourceIsAvailable() {
-    // arrange
-    JumperConfig jc = new JumperConfig();
-
-    // act & assert
-    assertEquals(Constants.DEFAULT_REALM, jc.determineRealmName(null));
+    assertEquals(Constants.DEFAULT_REALM, jc.determineRealmName());
   }
 
   @Test
   void determineRealmName_fallsBackToDefaultRealmWhenIssuerCarriesNoRealmSegment() {
     // arrange
-    JumperConfig jc = configWithGatewayClientIssuer("https://issuer/auth/no-realm-here");
+    JumperConfig jc = new JumperConfig();
+    jc.setInternalTokenEndpoint("http://localhost:1081/auth/no-realm-here");
 
     // act & assert
-    assertEquals(Constants.DEFAULT_REALM, jc.determineRealmName(null));
+    assertEquals(Constants.DEFAULT_REALM, jc.determineRealmName());
+  }
+
+  @Test
+  void fillProcessingInfo_keepsTheEntryRealmDespiteEveryConflictingSource() {
+    // arrange: the selected routing_config entry carries its own realm, while the request offers a
+    // conflicting realm header, a conflicting jumper_config gateway client and a conflicting mesh
+    // issuer. The entry must win - this is the non-overwrite invariant.
+    JumperConfig entry = routingConfigEntry(ENTRY_REALM, MESH_REALM);
+
+    // act
+    entry.fillProcessingInfo(
+        requestWith(HEADER_REALM, jumperConfigHeaderWithGatewayClientIssuer(GATEWAY_CLIENT_REALM)));
+
+    // assert
+    assertEquals(ENTRY_REALM, entry.getRealmName());
+  }
+
+  @Test
+  void fillProcessingInfo_ignoresTheRealmHeaderAndPrefersTheEntryIssuer() {
+    // arrange: no realm on the entry, so a fallback is used. The inbound realm header must not be
+    // it - the control plane leaves that header untouched on failover routes.
+    JumperConfig entry = routingConfigEntry(null, MESH_REALM);
+
+    // act
+    entry.fillProcessingInfo(
+        requestWith(HEADER_REALM, jumperConfigHeaderWithGatewayClientIssuer(GATEWAY_CLIENT_REALM)));
+
+    // assert
+    assertEquals(MESH_REALM, entry.getRealmName());
+  }
+
+  @Test
+  void fillProcessingInfo_fallsBackToDefaultRealmRatherThanTrustTheRealmHeader() {
+    // arrange: nothing trustworthy to derive a realm from, only a caller-supplied realm header
+    JumperConfig entry = routingConfigEntry(null, null);
+
+    // act
+    entry.fillProcessingInfo(requestWith(HEADER_REALM, null));
+
+    // assert
+    assertEquals(Constants.DEFAULT_REALM, entry.getRealmName());
   }
 
   @Test

--- a/src/test/java/jumper/util/RoutingConfigUtil.java
+++ b/src/test/java/jumper/util/RoutingConfigUtil.java
@@ -47,6 +47,20 @@ public class RoutingConfigUtil {
     };
   }
 
+  public static Consumer<HttpHeaders> getListenerRouteHeaders(BaseSteps baseSteps) {
+    return httpHeaders -> {
+      httpHeaders.setBearerAuth(baseSteps.getAuthHeader());
+      httpHeaders.set(Constants.HEADER_ROUTING_CONFIG, getRcListener(baseSteps.getId()));
+    };
+  }
+
+  public static String getRcListener(String id) {
+    // A listener route with zone failover configured: the zoned proxy entry the control plane
+    // sends carries an issuer but no realm, and it is the entry selected while the zone is
+    // healthy. The provider entry is the failover fallback.
+    return toJsonBase64(List.of(getProxyRouteJcOnCallback(id), getRealRouteJcOnCallback()));
+  }
+
   public static String getRcSecondary(String id) {
     // proxy + real
     return toJsonBase64(List.of(getProxyRouteJc(REMOTE_ZONE_NAME, id), getRealRouteJc()));
@@ -91,6 +105,13 @@ public class RoutingConfigUtil {
     return jc;
   }
 
+  private static JumperConfig getProxyRouteJcOnCallback(String id) {
+    JumperConfig jc = getProxyRouteJc(REMOTE_ZONE_NAME, id);
+    // aim the mesh hop at the /callback stub the listener steps set up
+    jc.setRemoteApiUrl(REMOTE_HOST);
+    return jc;
+  }
+
   private static JumperConfig getRealRouteJc() {
     JumperConfig jc = new JumperConfig();
     jc.setRemoteApiUrl(REMOTE_HOST + REMOTE_PROVIDER_BASE_PATH);
@@ -98,6 +119,13 @@ public class RoutingConfigUtil {
     jc.setRealmName(REALM);
     jc.setEnvName(ENVIRONMENT);
     jc.setAccessTokenForwarding(false);
+    return jc;
+  }
+
+  private static JumperConfig getRealRouteJcOnCallback() {
+    JumperConfig jc = getRealRouteJc();
+    // aim the failover fallback at the /callback stub as well
+    jc.setRemoteApiUrl(REMOTE_HOST);
     return jc;
   }
 

--- a/src/test/resources/features/spectre.feature
+++ b/src/test/resources/features/spectre.feature
@@ -94,3 +94,24 @@ Feature: spectre events created
     Given Event provider set to respond with a 201 status code
     When horizon calls the spectre route with HEAD
     Then horizon receives a 201 status code
+
+  ################ spectre + zone failover ################
+  Scenario: Consumer calls listener route with routing_config while the zone is healthy, 2 spectre events created
+    Given Listener routing_config header set
+    And jumperConfig with consumer route listener set
+    And IDP set to provide internal token
+    And API provider set to respond with a 200 status code
+    And horizon set to receive events
+    When consumer calls the listener route
+    Then API consumer receives a 200 status code
+    And verify 2 horizon events received
+
+  Scenario: Consumer calls listener route with routing_config and skipped zone, 2 spectre events created
+    Given Listener routing_config header set
+    And skip zone header set
+    And jumperConfig with consumer route listener set
+    And API provider set to respond with a 200 status code
+    And horizon set to receive events
+    When consumer calls the listener route
+    Then API consumer receives a 200 status code
+    And verify 2 horizon events received


### PR DESCRIPTION
## Symptom

**Every** request on a listener route belonging to a consumer with `failoverEnabled: true` returns a
500 and is never forwarded upstream. The trigger is a pair of configuration flags, not an endpoint:

- the consumer has **`failoverEnabled: true`** → the route carries a `routing_config` header, so
  Jumper takes the `fillProcessingInfo()` init path
- the route has a **Spectre listener** for that consumer → `SpectreRequestFilter` fires and needs a
  realm

Method and path are irrelevant — nothing on the failing code path reads either. The regression test
added in this PR reproduces the identical stack trace with a **GET** on `/listener/callback`. It was
first observed in prod as `DELETE /listener/services/{id}` on `a4m-content-ott-service-v2`
(`stargate-cetus.prod.tardis.telekom.de`, zone `cetus`), but that URI is incidental:

Blast radius is therefore *(consumers with `failoverEnabled: true`)* × *(their subscriptions carrying
a Spectre listener)*, and **100% of traffic on each such route** — not a subset of endpoints.

```
java.lang.NullPointerException: replacement
	at java.base/java.util.regex.Matcher.replaceFirst(Unknown Source)
	at java.base/java.lang.String.replaceFirst(Unknown Source)
	at jumper.service.SpectreService.publishEvent(SpectreService.java:140)
	at jumper.service.SpectreService.handleEvent(SpectreService.java:69)
	at jumper.filter.SpectreRequestFilter.lambda$apply$0(SpectreRequestFilter.java:54)
```

The trace contains the `spectre request` span but **no `outgoing request:` span at all** — Jumper dies
in the request filter before routing, so a telemetry-only failure takes down the customer's request.

## Root cause

`Matcher.replaceFirst` null-checks its replacement argument unconditionally, so
`publishEventUrl.replaceFirst(ENVIRONMENT_PLACEHOLDER, envName)` throws when `jc.getRealmName()` is
`null`. There is exactly one path on which it can be null:

| Route | Init path | realm |
|---|---|---|
| no `routing_config` header | `fillWithLegacyHeaders()` | `realm` header, else `DEFAULT_REALM` — never null |
| `routing_config` present (zone failover configured) | `fillProcessingInfo()` | only the selected entry's JSON `realm` — **null if absent** |

`routing_config` is the zone-failover construct (see the *Zone Failover* flowchart in the README),
and `JumperConfigService` branches on **header presence**, never on zone health. So failover only has
to be *configured*, not *active*: while the zone is healthy the first, zoned entry is selected — the
one that can arrive without a `realm`. Ironically, an actually-failed-over request lands on the
provider entry, which does carry a realm, and works.

`SpectreService` did not always read `realmName` directly. It used to resolve the realm through two
sources:

```java
private String determineEnvironment(JumperConfig jc) {
  if (jc.getGatewayClient().getIssuer() != null) {
    return jc.getGatewayClient().getIssuer().replaceFirst(".*realms/", "");
  }
  return jc.getRealmName();  // fallback
}
```

`gatewayClient` *is* populated on the `routing_config` path, so the primary branch covered exactly
this case. `d17b425` ("feat: replace Iris mesh token with self-signed LMS token", 2026-07-06) deleted
the method and inlined the fallback — `String envName = jc.getRealmName();` — collapsing onto the one
source that can be null. `77f592c` restored it, `940bf44` removed it again; both landed before
`4.12.3`, so no release ever carried the restoration.

**Affected: every release from `4.12.0` (2026-07-07) through `4.15.1`, plus `5.0.0-rc.1`.
Last good release: `4.11.1`.** `gatewayClient` has been write-only dead state ever since — set in
`fillProcessingInfo`, read nowhere.

## Control-plane context

In `telekom/controlplane` the realm reaches Jumper through two mutually exclusive channels, switched
by the same condition that switches Jumper's two init paths:

- `LastMileSecurityFeature.IsUsed()` returns `!PassThrough && route.Spec.Traffic.Failover == nil`, and
  it is what emits the `realm` / `environment` headers. **On a failover route those headers are not
  emitted at all.**
- `features/builder.go` appends `routing_config` **or** `jumper_config`, never both, so a failover
  route's realm depends solely on the per-entry `Realm` field — which is `json:"realm,omitempty"` and
  is only set when `options.RealmName != ""`.
- `failover.go` builds the primary proxy entry with `Realm: route.Spec.Security.RealmName` and **no
  fallback**, while the failover targets use `failoverRealm`, which does fall back. Asymmetric: an
  empty `Spec.Security.RealmName` silently omits the realm from exactly the entry that gets selected
  while zones are healthy.

Worth raising separately with the gateway/control-plane team; this PR makes Jumper robust regardless
of which producer is in front of it.

## Changes

1. **`JumperConfig`** — `fillProcessingInfo()` now resolves a missing realm from the routing_config
   blob only: the entry's own `realm` (never overwritten) → the realm embedded in the entry's
   `issuer` → `DEFAULT_REALM` with a warning. Strictly additive, so the legacy-header path keeps its
   existing precedence and an entry keeps the realm the control plane assigned it.

   Two channels are deliberately **not** used, because the realm selects the Horizon destination and
   the issuer of gateway-signed tokens and so must not be caller-writable. The inbound `realm`
   header: `LastMileSecurityFeature` is the only thing that adds/replaces it and it is skipped when
   `Failover != nil`, so on this path the header crosses Kong verbatim. And `gatewayClient.issuer`:
   `gatewayClient` is read from the `jumper_config` header, which `builder.go:280-284` emits
   *instead of* `routing_config` and never alongside it — with last-value-wins
   (`HeaderUtil.getLastValueFromHeaderField`) and no inbound strip, the caller's blob is the only one
   present, and the control plane never produces `gatewayClient` at all.

   This is also deliberately *not* `next`'s `determineRealm()`, which overwrites a legitimate
   per-entry realm and would trade the NPE for silent misrouting into the wrong Horizon environment.
2. **`SpectreService`** — `handleEvent()` wraps event construction in `Mono.defer` and hoists the
   error handler. The existing `onErrorResume`, commented *"Don't fail the main request flow"*, could
   only ever see signals from the assembled `Mono`, never the argument evaluation that builds it — so
   it has never worked. This is the change that matters most: it converts any future Spectre defect
   from a customer-facing 500 into a log line.
3. **`SpectreRequestFilter` / `SpectreResponseFilter`** — guard the `orElse(null)` config before
   dereferencing it.
4. **`SpectreService`** — `Matcher.quoteReplacement` on the `replaceFirst`; an unescaped `$` or `\`
   in a replacement string is interpreted by the regex engine rather than inserted literally.

## Tests

- `JumperConfigTest` — realm precedence, plus the non-overwrite invariant driven through
  `fillProcessingInfo()`: an entry realm survives a conflicting `realm` header, a conflicting
  `jumper_config` gateway-client issuer and a conflicting mesh issuer on the same request. Deleting
  the early return fails that test (it previously left the suite green).
- `spectre.feature` — two scenarios for listener + `routing_config`, one with the zone healthy (the
  production case) and one with the zone skipped (the path that works today and must keep working).
  The gap was structural: `spectre.feature` only ever used `RealRoute headers are set`, and
  `failover.feature` has no listener scenario, so this bug lived in the untested intersection.

## Out of scope, surfaced while verifying the review

Neither `jumper_config` nor `routing_config` is stripped or replaced at the Kong boundary
(`Config.Remove` only ever holds `consumer-token` and provider-declared transformation headers).
With last-value-wins, a caller can inject whichever of the two the control plane does not emit for a
given route. Injecting `routing_config` on a **non-failover** route is the sharper case:
`JumperConfigService.java:28` branches on mere header presence, flipping Jumper onto the failover
path with an entirely caller-authored config. On a failover route the same `jumper_config` line also
hands the caller `routeListener` — the Spectre on/off gate, and the source of the published event's
`issue`/`serviceOwner`. These look like boundary problems rather than precedence problems and want
separate issues.

## Follow-up (not in this PR)

`application-test.yml` sets `publishEventUrl: http://localhost:1082/v1/events` — no
`ENVIRONMENT_PLACEHOLDER` — so no test exercises the environment substitution at all, and the realm
value itself is unasserted end to end.
