### PR TITLE
feat(oauth): harden token fetch resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,36 @@ For local development and testing, Jumper uses Spring Boot's configuration mecha
 
 For additional standard Spring Boot properties, refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/appendix/application-properties/index.html).
 
+### OAuth Token Background Refresh
+
+Jumper refreshes cached OAuth tokens in the background while continuing to serve a token that is
+still safe to forward. This applies to tokens fetched for mesh routing and external authorization.
+The refresh policy can be configured with these environment variables:
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `JUMPER_OAUTH_TOKEN_FETCH_CONNECT_TIMEOUT` | `2s` | Maximum time allowed to establish the token endpoint connection. |
+| `JUMPER_OAUTH_TOKEN_FETCH_OVERALL_TIMEOUT` | `10s` | Maximum duration of one shared token fetch, including retries. |
+| `JUMPER_OAUTH_TOKEN_FETCH_REQUEST_WAIT_TIMEOUT` | `4s` | Maximum time one request waits for a shared token fetch. |
+| `JUMPER_OAUTH_TOKEN_FETCH_MAX_RETRIES` | `1` | Maximum retries after a retryable connection failure. |
+| `JUMPER_OAUTH_TOKEN_FETCH_RETRY_BACKOFF` | `200ms` | Initial retry backoff. |
+| `JUMPER_OAUTH_TOKEN_FETCH_MAX_RETRY_BACKOFF` | `1s` | Maximum retry backoff. |
+| `JUMPER_OAUTH_TOKEN_FETCH_ERROR_BODY_LOG_LIMIT` | `8KB` | Maximum identity provider error-body bytes retained for debug logging; the complete body is still drained. |
+| `JUMPER_OAUTH_TOKEN_FETCH_REFRESH_AHEAD` | `30s` | Start refreshing this long before token expiry. |
+| `JUMPER_OAUTH_TOKEN_FETCH_MIN_SERVE` | `10s` | Do not serve a token with this much lifetime or less remaining. |
+| `JUMPER_OAUTH_TOKEN_FETCH_MINIMUM_BACKGROUND_REFRESH_INTERVAL` | `5s` | Minimum interval after a background refresh finishes before the same token key may be refreshed again. |
+
+`refresh-ahead` must exceed `min-serve`, and `request-wait-timeout` must not exceed
+`overall-timeout`. The error-body log limit must be between `1B` and `64KB`. The minimum background
+refresh interval bounds request volume when a token's complete lifetime is shorter than
+`refresh-ahead`; once a token is no longer safe to serve, its foreground replacement ignores this
+interval.
+
+The former `spring.cloud.oauth.connect-timeout` property remains a deprecated fallback for the new
+connect-timeout setting. The former seconds-valued `jumper.tokencache.ttlOffset` property remains a
+deprecated fallback for `min-serve`. If its value is at least `refresh-ahead`, increase
+`JUMPER_OAUTH_TOKEN_FETCH_REFRESH_AHEAD` so it remains greater than `min-serve`.
+
 ## Usage Scenarios
 
 Jumper supports various token handling and routing scenarios.  

--- a/src/main/java/jumper/Application.java
+++ b/src/main/java/jumper/Application.java
@@ -4,11 +4,14 @@
 
 package jumper;
 
+import jumper.config.OauthTokenFetchProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableConfigurationProperties(OauthTokenFetchProperties.class)
 @EnableScheduling
 public class Application {
 

--- a/src/main/java/jumper/config/HttpClientConfiguration.java
+++ b/src/main/java/jumper/config/HttpClientConfiguration.java
@@ -36,9 +36,6 @@ import reactor.netty.transport.ProxyProvider;
 @Slf4j
 public class HttpClientConfiguration {
 
-  @Value("${spring.cloud.oauth.connect-timeout:10000}")
-  private int oauthConnectTimeout;
-
   @Value("${spring.cloud.oauth.pool.max-life-time:300}")
   private int oauthPoolMaxLifeTime;
 
@@ -54,6 +51,7 @@ public class HttpClientConfiguration {
   private final HttpClientProperties properties;
   private final TlsHardeningConfiguration tlsHardeningConfiguration;
   private final MeterRegistry meterRegistry;
+  private final OauthTokenFetchProperties oauthTokenFetchProperties;
 
   @Bean
   public HttpClientCustomizer httpClientCustomizer() throws SSLException {
@@ -73,7 +71,9 @@ public class HttpClientConfiguration {
     HttpClient httpClient =
         HttpClient.create(getProvider())
             .secure(t -> t.sslContext(sslContext))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, oauthConnectTimeout);
+            .option(
+                ChannelOption.CONNECT_TIMEOUT_MILLIS,
+                Math.toIntExact(oauthTokenFetchProperties.connectTimeout().toMillis()));
     httpClient = configureProxy(httpClient);
 
     return webClientBuilder.clientConnector(new ReactorClientHttpConnector(httpClient)).build();

--- a/src/main/java/jumper/config/OauthTokenFetchProperties.java
+++ b/src/main/java/jumper/config/OauthTokenFetchProperties.java
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.config;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.hibernate.validator.constraints.time.DurationMin;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.util.unit.DataSize;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties("jumper.oauth.token-fetch")
+@Validated
+public record OauthTokenFetchProperties(
+    @NotNull @DurationMin(millis = 1) @DurationUnit(ChronoUnit.MILLIS) Duration connectTimeout,
+    @NotNull @DurationMin(millis = 1) @DurationUnit(ChronoUnit.MILLIS) Duration overallTimeout,
+    @NotNull @DurationMin(millis = 1) @DurationUnit(ChronoUnit.MILLIS) Duration requestWaitTimeout,
+    @Min(0) int maxRetries,
+    @NotNull @DurationMin(millis = 1) @DurationUnit(ChronoUnit.MILLIS) Duration retryBackoff,
+    @NotNull @DurationMin(millis = 1) @DurationUnit(ChronoUnit.MILLIS) Duration maxRetryBackoff,
+    @NotNull DataSize errorBodyLogLimit,
+    @NotNull @DurationMin(seconds = 1) @DurationUnit(ChronoUnit.SECONDS) Duration refreshAhead,
+    @NotNull @DurationMin(seconds = 1) @DurationUnit(ChronoUnit.SECONDS) Duration minServe,
+    @NotNull @DurationMin(seconds = 1) @DurationUnit(ChronoUnit.SECONDS)
+        Duration minimumBackgroundRefreshInterval) {
+
+  private static final long MAX_ERROR_BODY_LOG_BYTES = DataSize.ofKilobytes(64).toBytes();
+
+  @AssertTrue(message = "refreshAhead must exceed minServe")
+  public boolean isRefreshConfigurationValid() {
+    if (refreshAhead == null || minServe == null) {
+      return true;
+    }
+
+    return refreshAhead.compareTo(minServe) > 0;
+  }
+
+  @AssertTrue(message = "requestWaitTimeout must not exceed overallTimeout")
+  public boolean isTimeoutConfigurationValid() {
+    if (requestWaitTimeout == null || overallTimeout == null) {
+      return true;
+    }
+
+    return requestWaitTimeout.compareTo(overallTimeout) <= 0;
+  }
+
+  @AssertTrue(message = "maxRetryBackoff must not be shorter than retryBackoff")
+  public boolean isRetryConfigurationValid() {
+    if (retryBackoff == null || maxRetryBackoff == null) {
+      return true;
+    }
+
+    return maxRetryBackoff.compareTo(retryBackoff) >= 0;
+  }
+
+  @AssertTrue(message = "errorBodyLogLimit must be between 1B and 64KB")
+  public boolean isErrorBodyLogLimitValid() {
+    if (errorBodyLogLimit == null) {
+      return true;
+    }
+
+    long bytes = errorBodyLogLimit.toBytes();
+    return bytes > 0 && bytes <= MAX_ERROR_BODY_LOG_BYTES;
+  }
+}

--- a/src/main/java/jumper/exception/JsonErrorWebExceptionHandler.java
+++ b/src/main/java/jumper/exception/JsonErrorWebExceptionHandler.java
@@ -45,8 +45,6 @@ public class JsonErrorWebExceptionHandler extends DefaultErrorWebExceptionHandle
   @Value("${spring.application.name}")
   private String applicationName;
 
-  private Map<String, String> customResponseHeaders;
-
   public JsonErrorWebExceptionHandler(
       ErrorAttributes errorAttributes,
       Resources resources,
@@ -109,8 +107,8 @@ public class JsonErrorWebExceptionHandler extends DefaultErrorWebExceptionHandle
     ServerResponse.BodyBuilder responseBuilder =
         ServerResponse.status(this.getHttpStatus(error)).contentType(MediaType.APPLICATION_JSON);
 
-    if (!customResponseHeaders.isEmpty()) {
-      customResponseHeaders.forEach(responseBuilder::header);
+    if (shouldAddRetryAfter(super.getError(request))) {
+      responseBuilder.header("Retry-After", "30");
     }
 
     return responseBuilder.body(BodyInserters.fromValue(error));
@@ -132,8 +130,6 @@ public class JsonErrorWebExceptionHandler extends DefaultErrorWebExceptionHandle
       ServerRequest request,
       Throwable error,
       MergedAnnotation<ResponseStatus> responseStatusAnnotation) {
-    customResponseHeaders = new HashMap<>();
-
     if (error instanceof ResponseStatusException) {
       return HttpStatus.valueOf(((ResponseStatusException) error).getStatusCode().value());
     }
@@ -151,7 +147,6 @@ public class JsonErrorWebExceptionHandler extends DefaultErrorWebExceptionHandle
 
     if (error instanceof java.net.UnknownHostException) {
       logError(request, error);
-      customResponseHeaders.put("Retry-After", "30");
       return HttpStatus.SERVICE_UNAVAILABLE;
     }
 
@@ -162,6 +157,10 @@ public class JsonErrorWebExceptionHandler extends DefaultErrorWebExceptionHandle
 
   private void logError(ServerRequest request, Throwable throwable) {
     log.error(request.exchange().getLogPrefix() + this.formatError(throwable, request));
+  }
+
+  private boolean shouldAddRetryAfter(Throwable error) {
+    return error instanceof java.net.UnknownHostException;
   }
 
   private String formatError(Throwable ex, ServerRequest request) {

--- a/src/main/java/jumper/exception/TokenFetchUnavailableException.java
+++ b/src/main/java/jumper/exception/TokenFetchUnavailableException.java
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public final class TokenFetchUnavailableException extends ResponseStatusException {
+
+  public TokenFetchUnavailableException(String tokenEndpoint, Throwable cause) {
+    super(
+        HttpStatus.UNAUTHORIZED,
+        "Failed to connect to " + tokenEndpoint + ", cause: " + cause.getMessage(),
+        cause);
+  }
+}

--- a/src/main/java/jumper/service/TokenCacheService.java
+++ b/src/main/java/jumper/service/TokenCacheService.java
@@ -4,30 +4,51 @@
 
 package jumper.service;
 
-import java.util.Optional;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import jumper.config.OauthTokenFetchProperties;
 import jumper.model.TokenInfo;
 import jumper.model.config.OauthCredentials;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 @Service
 @Slf4j
 public class TokenCacheService {
 
-  @Value("${jumper.tokencache.ttlOffset}")
-  private int ttlOffset;
-
   private static final String TOKEN_CACHE_KEY_DELIMITER = ".";
   private static final String TOKEN_CACHE_NAME = "cache-token-info";
 
   private final Cache tokenCache;
+  private final OauthTokenFetchProperties tokenFetchProperties;
+  private final Clock clock;
+  private final ConcurrentHashMap<String, Mono<TokenInfo>> activeFetches =
+      new ConcurrentHashMap<>();
 
-  public TokenCacheService(@Qualifier("caffeineCacheManager") CacheManager cacheManager) {
+  @Autowired
+  public TokenCacheService(
+      @Qualifier("caffeineCacheManager") CacheManager cacheManager,
+      OauthTokenFetchProperties tokenFetchProperties) {
+    this(cacheManager, tokenFetchProperties, Clock.systemUTC());
+  }
+
+  TokenCacheService(
+      CacheManager cacheManager, OauthTokenFetchProperties tokenFetchProperties, Clock clock) {
     this.tokenCache = cacheManager.getCache(TOKEN_CACHE_NAME);
+    this.tokenFetchProperties = tokenFetchProperties;
+    this.clock = clock;
     if (this.tokenCache == null) {
       throw new IllegalStateException(
           "Cache '" + TOKEN_CACHE_NAME + "' not found. Please check cache configuration.");
@@ -35,81 +56,178 @@ public class TokenCacheService {
     log.debug("TokenCacheService initialized with Spring-managed cache: {}", TOKEN_CACHE_NAME);
   }
 
-  public Optional<TokenInfo> getToken(String tokenCacheKey) {
-    log.debug("try to grab token from cache with key: {}", tokenCacheKey);
+  public TokenLookup lookup(String tokenCacheKey) {
+    log.debug("Looking up token from cache with key: {}", tokenCacheKey);
 
     TokenInfo token = tokenCache.get(tokenCacheKey, TokenInfo.class);
-
-    // Additional TTL validation with offset
-    if (token != null && !isValid(token)) {
-      log.debug(
-          "TTL: {} seconds | Token will expire within {} seconds, removing from cache",
-          token.getExpiresIn(),
-          this.ttlOffset);
-      tokenCache.evict(tokenCacheKey);
-      return Optional.empty();
+    if (token == null) {
+      return new TokenLookup(null, Freshness.NOT_SERVABLE);
+    }
+    if (token.getExpiration() == null) {
+      return new TokenLookup(token, Freshness.FRESH);
     }
 
-    return Optional.ofNullable(token);
+    Duration remaining = Duration.ofMillis(token.getExpiration().getTime() - clock.millis());
+    if (remaining.compareTo(tokenFetchProperties.minServe()) <= 0) {
+      return new TokenLookup(null, Freshness.NOT_SERVABLE);
+    }
+
+    Freshness freshness =
+        remaining.compareTo(tokenFetchProperties.refreshAhead()) <= 0
+            ? Freshness.NEEDS_REFRESH
+            : Freshness.FRESH;
+    return new TokenLookup(token, freshness);
   }
 
-  public void saveToken(String tokenKey, TokenInfo gwAccessToken) {
+  void saveToken(String tokenKey, TokenInfo gwAccessToken) {
     log.debug("Token saved with tokenKey: '{}'", tokenKey);
     tokenCache.put(tokenKey, gwAccessToken);
   }
 
+  /**
+   * Atomically selects the active fetch for a token key. The caller owns subscribing to the
+   * candidate only when {@link FetchSelection#created()} is true.
+   */
+  public FetchSelection getOrCreateFetch(String tokenKey, Mono<TokenInfo> candidate) {
+    boolean[] created = {false};
+    Mono<TokenInfo> selected =
+        activeFetches.compute(
+            tokenKey,
+            (key, existing) -> {
+              if (existing != null) {
+                return existing;
+              }
+              created[0] = true;
+              return candidate;
+            });
+    return new FetchSelection(selected, created[0]);
+  }
+
+  /**
+   * Saves a fetched token only while that exact fetch is still current for the key. Cache writes
+   * intentionally run inside the per-key map operation and must not re-enter {@code activeFetches};
+   * this linearizes the identity check and write against eviction.
+   */
+  public boolean saveTokenIfFetchMatches(String tokenKey, Mono<TokenInfo> fetch, TokenInfo token) {
+    boolean[] saved = new boolean[1];
+    activeFetches.computeIfPresent(
+        tokenKey,
+        (key, current) -> {
+          if (current == fetch) {
+            tokenCache.put(tokenKey, token);
+            saved[0] = true;
+            log.debug("Token saved with tokenKey: '{}'", tokenKey);
+          }
+          return current;
+        });
+    return saved[0];
+  }
+
+  /** Removes a completed fetch without removing a replacement installed after eviction. */
+  public void completeFetch(String tokenKey, Mono<TokenInfo> fetch) {
+    activeFetches.remove(tokenKey, fetch);
+  }
+
+  /**
+   * Atomically invalidates any active fetch and evicts its cached token. Cache eviction
+   * intentionally runs inside the per-key map operation and must not re-enter {@code
+   * activeFetches}.
+   */
   public void evictToken(String tokenCacheKey) {
     if (tokenCacheKey != null) {
-      log.debug("Evicting token from cache with key: '{}'", tokenCacheKey);
-      tokenCache.evict(tokenCacheKey);
+      // Keep invalidation and eviction in one per-key critical section. Otherwise an older fetch
+      // could save between those operations and repopulate a token rejected by the provider.
+      activeFetches.compute(
+          tokenCacheKey,
+          (key, fetch) -> {
+            log.debug("Evicting token from cache with key: '{}'", tokenCacheKey);
+            tokenCache.evict(tokenCacheKey);
+            return null;
+          });
     }
+  }
+
+  int activeFetchCount() {
+    return activeFetches.size();
   }
 
   public String generateTokenCacheKey(String tokenEndpoint, OauthCredentials oauthCredentials) {
     return generateTokenCacheKey(
         tokenEndpoint,
-        oauthCredentials.getId(),
+        oauthCredentials.getClientId(),
         oauthCredentials.getClientSecret(),
-        oauthCredentials.getScopes());
+        oauthCredentials.getClientKey(),
+        oauthCredentials.getUsername(),
+        oauthCredentials.getPassword(),
+        oauthCredentials.getRefreshToken(),
+        oauthCredentials.getScopes(),
+        oauthCredentials.getGrantType());
   }
 
   public String generateTokenCacheKey(
       String tokenEndpoint, String clientID, String clientSecret, String scopes) {
-    String safeScopes = scopes != null ? scopes : "";
-    String hashedCredentials = hashCredentials(clientID, clientSecret);
-    return tokenEndpoint
-        + TOKEN_CACHE_KEY_DELIMITER
-        + clientID
-        + TOKEN_CACHE_KEY_DELIMITER
-        + hashedCredentials
-        + TOKEN_CACHE_KEY_DELIMITER
-        + safeScopes;
+    return generateTokenCacheKey(
+        tokenEndpoint,
+        clientID,
+        clientSecret,
+        null,
+        null,
+        null,
+        null,
+        scopes,
+        AuthorizationGrantType.CLIENT_CREDENTIALS.getValue());
   }
 
-  private boolean isValid(TokenInfo token) {
-    // If expiration is null (no expires_in in token response), treat as valid.
-    // Rely on cache's TTL (30 min max via expireAfterWrite) and 4xx-based eviction.
-    if (token.getExpiration() == null) {
-      return true;
-    }
-    return token.getExpiresIn() > this.ttlOffset;
+  private String generateTokenCacheKey(String tokenEndpoint, String... credentialFields) {
+    return tokenEndpoint + TOKEN_CACHE_KEY_DELIMITER + hashCredentials(credentialFields);
   }
 
-  private String hashCredentials(String clientId, String clientSecret) {
+  private String hashCredentials(String... values) {
     try {
-      String combined =
-          (clientId != null ? clientId : "") + (clientSecret != null ? clientSecret : "");
-      java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
-      byte[] hash = digest.digest(combined.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      for (String value : values) {
+        byte[] bytes = value == null ? new byte[0] : value.getBytes(StandardCharsets.UTF_8);
+        digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+        digest.update(bytes);
+      }
+      byte[] hash = digest.digest();
       StringBuilder hexString = new StringBuilder();
       for (byte b : hash) {
         String hex = Integer.toHexString(0xff & b);
-        if (hex.length() == 1) hexString.append('0');
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
         hexString.append(hex);
       }
       return hexString.toString();
-    } catch (java.security.NoSuchAlgorithmException e) {
-      throw new RuntimeException("SHA-256 algorithm not available", e);
+    } catch (NoSuchAlgorithmException error) {
+      throw new IllegalStateException("SHA-256 algorithm not available", error);
     }
   }
+
+  public enum Freshness {
+    FRESH,
+    NEEDS_REFRESH,
+    NOT_SERVABLE
+  }
+
+  public record TokenLookup(TokenInfo token, Freshness freshness) {
+
+    public TokenLookup {
+      Objects.requireNonNull(freshness, "freshness");
+      if (freshness != Freshness.NOT_SERVABLE) {
+        Objects.requireNonNull(token, "A servable token lookup requires a token");
+      }
+    }
+
+    public boolean servable() {
+      return freshness != Freshness.NOT_SERVABLE;
+    }
+
+    public boolean needsRefresh() {
+      return freshness == Freshness.NEEDS_REFRESH;
+    }
+  }
+
+  public record FetchSelection(Mono<TokenInfo> publisher, boolean created) {}
 }

--- a/src/main/java/jumper/service/TokenFetchMetrics.java
+++ b/src/main/java/jumper/service/TokenFetchMetrics.java
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenFetchMetrics {
+
+  private static final String FETCH_METRIC = "jumper.oauth.token.fetch";
+
+  private final Map<Mode, Map<Outcome, Counter>> outcomeCounters = new EnumMap<>(Mode.class);
+  private final Map<Mode, Counter> retryCounters = new EnumMap<>(Mode.class);
+  private final AtomicInteger activeFetches = new AtomicInteger();
+  private final AtomicInteger waiters = new AtomicInteger();
+
+  public TokenFetchMetrics(MeterRegistry meterRegistry) {
+    for (Mode mode : Mode.values()) {
+      Map<Outcome, Counter> counters = new EnumMap<>(Outcome.class);
+      for (Outcome outcome : Outcome.values()) {
+        counters.put(
+            outcome,
+            meterRegistry.counter(
+                FETCH_METRIC, "outcome", outcome.tagValue, "mode", mode.tagValue));
+      }
+      outcomeCounters.put(mode, counters);
+      retryCounters.put(
+          mode, meterRegistry.counter("jumper.oauth.token.retries", "mode", mode.tagValue));
+    }
+    meterRegistry.gauge("jumper.oauth.token.fetch.active", activeFetches);
+    meterRegistry.gauge("jumper.oauth.token.waiters", waiters);
+  }
+
+  public void record(Outcome outcome, Mode mode) {
+    outcomeCounters.get(mode).get(outcome).increment();
+  }
+
+  public void recordRetry(Mode mode) {
+    retryCounters.get(mode).increment();
+  }
+
+  public void fetchStarted() {
+    activeFetches.incrementAndGet();
+  }
+
+  public void fetchFinished() {
+    activeFetches.decrementAndGet();
+  }
+
+  public void waiterStarted() {
+    waiters.incrementAndGet();
+  }
+
+  public void waiterFinished() {
+    waiters.decrementAndGet();
+  }
+
+  public enum Outcome {
+    SUCCESS("success"),
+    CACHE_HIT("cache_hit"),
+    CONNECT_FAILURE("connect_failure"),
+    DEADLINE("deadline"),
+    RETRY_EXHAUSTED("retry_exhausted"),
+    IDP_ERROR("idp_error"),
+    BACKGROUND_REFRESH_FAILURE("background_refresh_failure"),
+    REQUEST_BUILD_FAILURE("request_build_failure");
+
+    private final String tagValue;
+
+    Outcome(String tagValue) {
+      this.tagValue = tagValue;
+    }
+  }
+
+  public enum Mode {
+    FOREGROUND("foreground"),
+    BACKGROUND("background");
+
+    private final String tagValue;
+
+    Mode(String tagValue) {
+      this.tagValue = tagValue;
+    }
+  }
+}

--- a/src/main/java/jumper/service/TokenFetchService.java
+++ b/src/main/java/jumper/service/TokenFetchService.java
@@ -5,26 +5,43 @@
 package jumper.service;
 
 import static jumper.Constants.TOKEN_REQUEST_METHOD_POST;
+import static jumper.service.TokenFetchMetrics.Mode.BACKGROUND;
+import static jumper.service.TokenFetchMetrics.Mode.FOREGROUND;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.ssl.SslHandshakeTimeoutException;
+import java.io.ByteArrayOutputStream;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.net.UnknownHostException;
-import java.time.Duration;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import jumper.Constants;
+import jumper.config.OauthTokenFetchProperties;
+import jumper.exception.TokenFetchUnavailableException;
 import jumper.model.TokenInfo;
 import jumper.model.config.JumperConfig;
 import jumper.model.config.OauthCredentials;
+import jumper.service.TokenCacheService.FetchSelection;
+import jumper.service.TokenFetchMetrics.Mode;
+import jumper.service.TokenFetchMetrics.Outcome;
 import jumper.util.BasicAuthUtil;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -45,7 +62,6 @@ import reactor.util.retry.Retry;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class TokenFetchService {
 
   @Qualifier("oauthTokenUtilWebClient")
@@ -53,9 +69,45 @@ public class TokenFetchService {
 
   private final TokenCacheService tokenCache;
   private final TokenGeneratorService tokenGeneratorService;
+  private final OauthTokenFetchProperties tokenFetchProperties;
+  private final TokenFetchMetrics metrics;
+  private final Cache<String, Boolean> recentBackgroundRefreshAttempts;
 
-  private final ConcurrentHashMap<String, Mono<TokenInfo>> inFlightTokenRequests =
-      new ConcurrentHashMap<>();
+  @Autowired
+  public TokenFetchService(
+      @Qualifier("oauthTokenUtilWebClient") WebClient oauthTokenUtilWebClient,
+      TokenCacheService tokenCache,
+      TokenGeneratorService tokenGeneratorService,
+      TokenFetchMetrics metrics,
+      OauthTokenFetchProperties tokenFetchProperties) {
+    this(
+        oauthTokenUtilWebClient,
+        tokenCache,
+        tokenGeneratorService,
+        metrics,
+        tokenFetchProperties,
+        Ticker.systemTicker());
+  }
+
+  TokenFetchService(
+      WebClient oauthTokenUtilWebClient,
+      TokenCacheService tokenCache,
+      TokenGeneratorService tokenGeneratorService,
+      TokenFetchMetrics metrics,
+      OauthTokenFetchProperties tokenFetchProperties,
+      Ticker ticker) {
+    this.oauthTokenUtilWebClient = oauthTokenUtilWebClient;
+    this.tokenCache = tokenCache;
+    this.tokenGeneratorService = tokenGeneratorService;
+    this.tokenFetchProperties = tokenFetchProperties;
+    this.metrics = metrics;
+    this.recentBackgroundRefreshAttempts =
+        Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(tokenFetchProperties.minimumBackgroundRefreshInterval())
+            .ticker(ticker)
+            .build();
+  }
 
   public Mono<TokenInfo> getInternalMeshAccessToken(JumperConfig jc) {
     return getAccessTokenWithClientCredentials(
@@ -71,29 +123,12 @@ public class TokenFetchService {
     final String tokenKey =
         tokenCache.generateTokenCacheKey(tokenEndpoint, clientID, clientSecret, scope);
 
-    // try to get valid token from tokenCache...
     return Mono.defer(
         () ->
-            tokenCache
-                .getToken(tokenKey)
-                .map(Mono::just)
-                .orElseGet(
-                    () -> { // ...otherwise retrieve a new one, coalescing concurrent requests
-                      MultiValueMap<String, String> requestParameter = new LinkedMultiValueMap<>();
-                      requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID, clientID);
-                      requestParameter.add(
-                          Constants.TOKEN_REQUEST_PARAMETER_CLIENT_SECRET, clientSecret);
-                      requestParameter.add(
-                          Constants.TOKEN_REQUEST_PARAMETER_GRANT_TYPE,
-                          AuthorizationGrantType.CLIENT_CREDENTIALS.getValue());
-
-                      if (StringUtils.isNotBlank(scope)) {
-                        requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_SCOPE, scope);
-                      }
-
-                      return getOrCreateInFlightRequest(
-                          tokenEndpoint, tokenKey, requestParameter, null);
-                    }));
+            resolveToken(
+                tokenEndpoint,
+                tokenKey,
+                () -> createClientCredentialsRequest(clientID, clientSecret, scope)));
   }
 
   public Mono<TokenInfo> getAccessTokenWithOauthCredentialsObject(
@@ -101,90 +136,152 @@ public class TokenFetchService {
 
     final String tokenKey = tokenCache.generateTokenCacheKey(tokenEndpoint, oauthCredentials);
 
-    // try to get valid token from tokenCache...
     return Mono.defer(
         () ->
-            tokenCache
-                .getToken(tokenKey)
-                .map(Mono::just)
-                .orElseGet(
-                    () -> { // ...otherwise retrieve a new one, coalescing concurrent requests
-                      MultiValueMap<String, String> requestParameter = new LinkedMultiValueMap<>();
-                      String basicAuth = null;
+            resolveToken(
+                tokenEndpoint,
+                tokenKey,
+                () -> createOauthCredentialsRequest(tokenEndpoint, oauthCredentials)));
+  }
 
-                      if (StringUtils.isNotBlank(oauthCredentials.getClientKey())) {
-                        requestParameter.add(
-                            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID,
-                            oauthCredentials.getClientId());
-                        requestParameter.add(
-                            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION,
-                            createJwtTokenForExternalIdp(tokenEndpoint, oauthCredentials));
-                        requestParameter.add(
-                            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION_TYPE,
-                            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION_TYPE_JWT);
-                      }
+  private Mono<TokenInfo> resolveToken(
+      String tokenEndpoint, String tokenKey, Supplier<TokenRequest> requestSupplier) {
+    TokenCacheService.TokenLookup cached = tokenCache.lookup(tokenKey);
+    if (cached.servable()) {
+      metrics.record(Outcome.CACHE_HIT, FOREGROUND);
+      if (cached.needsRefresh()) {
+        tryStartBackgroundRefresh(tokenEndpoint, tokenKey, requestSupplier);
+      }
+      return Mono.just(cached.token());
+    }
 
-                      if (StringUtils.isNotBlank(oauthCredentials.getClientId())
-                          && StringUtils.isNotBlank(oauthCredentials.getClientSecret())) {
+    return getOrCreateInFlightRequest(tokenEndpoint, tokenKey, requestSupplier);
+  }
 
-                        if (StringUtils.isNotBlank(oauthCredentials.getTokenRequest())
-                            && StringUtils.equalsIgnoreCase(
-                                TOKEN_REQUEST_METHOD_POST, oauthCredentials.getTokenRequest())) {
-                          requestParameter.add(
-                              Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID,
-                              oauthCredentials.getClientId());
-                          requestParameter.add(
-                              Constants.TOKEN_REQUEST_PARAMETER_CLIENT_SECRET,
-                              oauthCredentials.getClientSecret());
-                        } else {
-                          basicAuth =
-                              BasicAuthUtil.encodeBasicAuth(
-                                  oauthCredentials.getClientId(),
-                                  oauthCredentials.getClientSecret());
-                        }
-                      }
+  private TokenRequest createClientCredentialsRequest(
+      String clientID, String clientSecret, String scope) {
+    MultiValueMap<String, String> requestParameter = new LinkedMultiValueMap<>();
+    requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID, clientID);
+    requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_CLIENT_SECRET, clientSecret);
+    requestParameter.add(
+        Constants.TOKEN_REQUEST_PARAMETER_GRANT_TYPE,
+        AuthorizationGrantType.CLIENT_CREDENTIALS.getValue());
 
-                      if (StringUtils.isNotBlank(oauthCredentials.getUsername())
-                          && StringUtils.isNotBlank(oauthCredentials.getPassword())) {
+    if (StringUtils.isNotBlank(scope)) {
+      requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_SCOPE, scope);
+    }
 
-                        requestParameter.add(
-                            Constants.TOKEN_REQUEST_PARAMETER_USERNAME,
-                            oauthCredentials.getUsername());
-                        requestParameter.add(
-                            Constants.TOKEN_REQUEST_PARAMETER_PASSWORD,
-                            oauthCredentials.getPassword());
-                      }
+    return new TokenRequest(requestParameter, null);
+  }
 
-                      if (StringUtils.isNotBlank(oauthCredentials.getRefreshToken())) {
-                        requestParameter.add(
-                            Constants.TOKEN_REQUEST_PARAMETER_REFRESH_TOKEN,
-                            oauthCredentials.getRefreshToken());
-                      }
+  private TokenRequest createOauthCredentialsRequest(
+      String tokenEndpoint, OauthCredentials oauthCredentials) {
+    MultiValueMap<String, String> requestParameter = new LinkedMultiValueMap<>();
+    String basicAuth = null;
 
-                      if (StringUtils.isNotEmpty(oauthCredentials.getScopes())) {
-                        requestParameter.add(
-                            Constants.TOKEN_REQUEST_PARAMETER_SCOPE, oauthCredentials.getScopes());
-                      }
+    if (StringUtils.isNotBlank(oauthCredentials.getClientKey())) {
+      requestParameter.add(
+          Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID, oauthCredentials.getClientId());
+      requestParameter.add(
+          Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION,
+          createJwtTokenForExternalIdp(tokenEndpoint, oauthCredentials));
+      requestParameter.add(
+          Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION_TYPE,
+          Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ASSERTION_TYPE_JWT);
+    }
 
-                      requestParameter.add(
-                          Constants.TOKEN_REQUEST_PARAMETER_GRANT_TYPE,
-                          oauthCredentials.getGrantType());
+    if (StringUtils.isNotBlank(oauthCredentials.getClientId())
+        && StringUtils.isNotBlank(oauthCredentials.getClientSecret())) {
+      if (StringUtils.isNotBlank(oauthCredentials.getTokenRequest())
+          && oauthCredentials.getTokenRequest().equalsIgnoreCase(TOKEN_REQUEST_METHOD_POST)) {
+        requestParameter.add(
+            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_ID, oauthCredentials.getClientId());
+        requestParameter.add(
+            Constants.TOKEN_REQUEST_PARAMETER_CLIENT_SECRET, oauthCredentials.getClientSecret());
+      } else {
+        basicAuth =
+            BasicAuthUtil.encodeBasicAuth(
+                oauthCredentials.getClientId(), oauthCredentials.getClientSecret());
+      }
+    }
 
-                      return getOrCreateInFlightRequest(
-                          tokenEndpoint, tokenKey, requestParameter, basicAuth);
-                    }));
+    if (StringUtils.isNotBlank(oauthCredentials.getUsername())
+        && StringUtils.isNotBlank(oauthCredentials.getPassword())) {
+      requestParameter.add(
+          Constants.TOKEN_REQUEST_PARAMETER_USERNAME, oauthCredentials.getUsername());
+      requestParameter.add(
+          Constants.TOKEN_REQUEST_PARAMETER_PASSWORD, oauthCredentials.getPassword());
+    }
+
+    if (StringUtils.isNotBlank(oauthCredentials.getRefreshToken())) {
+      requestParameter.add(
+          Constants.TOKEN_REQUEST_PARAMETER_REFRESH_TOKEN, oauthCredentials.getRefreshToken());
+    }
+
+    if (StringUtils.isNotEmpty(oauthCredentials.getScopes())) {
+      requestParameter.add(Constants.TOKEN_REQUEST_PARAMETER_SCOPE, oauthCredentials.getScopes());
+    }
+
+    requestParameter.add(
+        Constants.TOKEN_REQUEST_PARAMETER_GRANT_TYPE, oauthCredentials.getGrantType());
+    return new TokenRequest(requestParameter, basicAuth);
+  }
+
+  /**
+   * Starts a background refresh unless this token key is still in its refresh cooldown.
+   *
+   * <p>The cooldown starts when this service creates the shared refresh request and restarts when
+   * the request terminates, regardless of its outcome. Foreground token fetches do not use this
+   * gate.
+   */
+  private void tryStartBackgroundRefresh(
+      String tokenEndpoint, String tokenKey, Supplier<TokenRequest> requestSupplier) {
+    if (recentBackgroundRefreshAttempts.getIfPresent(tokenKey) != null) {
+      return;
+    }
+
+    FetchSelection refresh =
+        getOrCreateSharedRequest(tokenEndpoint, tokenKey, requestSupplier, BACKGROUND);
+
+    if (!refresh.created()) {
+      return;
+    }
+
+    recentBackgroundRefreshAttempts.put(tokenKey, Boolean.TRUE);
+    refresh
+        .publisher()
+        .subscribe(
+            ignored -> {}, error -> recordBackgroundRefreshFailure(tokenEndpoint, tokenKey, error));
+  }
+
+  private void recordBackgroundRefreshFailure(
+      String tokenEndpoint, String tokenKey, Throwable error) {
+    metrics.record(Outcome.BACKGROUND_REFRESH_FAILURE, BACKGROUND);
+    log.warn(
+        "Background token refresh failed for endpoint {}: {}: {}",
+        tokenEndpoint,
+        error.getClass().getSimpleName(),
+        error.getMessage());
+    log.debug("Background token refresh failure details", error);
   }
 
   private String createJwtTokenForExternalIdp(
       String tokenEndpoint, OauthCredentials oauthCredentials) {
     /*
-    iss - REQUIRED. Issuer. This MUST contain the client_id of the OAuth Client.
-    sub - REQUIRED. Subject. This MUST contain the client_id of the OAuth Client.
-    aud - REQUIRED. Audience. The aud (audience) Claim. Value that identifies the Authorization Server as an intended audience. The Authorization Server MUST verify that it is an intended audience for the token. The Audience SHOULD be the URL of the Authorization Server's Token Endpoint.
-    jti - REQUIRED. JWT ID. A unique identifier for the token, which can be used to prevent reuse of the token. These tokens MUST only be used once, unless conditions for reuse were negotiated between the parties; any such negotiation is beyond the scope of this specification.
-    exp - REQUIRED. Expiration time on or after which the JWT MUST NOT be accepted for processing.
-    iat - OPTIONAL. Time at which the JWT was issued.
-    */
+     * iss - REQUIRED. Issuer. This MUST contain the client_id of the OAuth Client.
+     * sub - REQUIRED. Subject. This MUST contain the client_id of the OAuth Client.
+     * aud - REQUIRED. Audience. The aud (audience) Claim. Value that identifies the
+     * Authorization Server as an intended audience. The Authorization Server MUST
+     * verify that it is an intended audience for the token. The Audience SHOULD be
+     * the URL of the Authorization Server's Token Endpoint.
+     * jti - REQUIRED. JWT ID. A unique identifier for the token, which can be used
+     * to prevent reuse of the token. These tokens MUST only be used once, unless
+     * conditions for reuse were negotiated between the parties; any such
+     * negotiation is beyond the scope of this specification.
+     * exp - REQUIRED. Expiration time on or after which the JWT MUST NOT be
+     * accepted for processing.
+     * iat - OPTIONAL. Time at which the JWT was issued.
+     */
     Claims claims =
         Jwts.claims()
             .subject(oauthCredentials.getClientId())
@@ -203,25 +300,108 @@ public class TokenFetchService {
   }
 
   private Mono<TokenInfo> getOrCreateInFlightRequest(
-      String tokenEndpoint,
-      String tokenKey,
-      MultiValueMap<String, String> formData,
-      String basicAuthHeader) {
-    return inFlightTokenRequests.computeIfAbsent(
-        tokenKey,
-        k -> {
-          log.debug("Creating new token request for key: {}", tokenKey);
-          return getAccessTokenQuery(tokenEndpoint, tokenKey, formData, basicAuthHeader)
-              .doFinally(signal -> inFlightTokenRequests.remove(tokenKey))
-              .cache();
+      String tokenEndpoint, String tokenKey, Supplier<TokenRequest> requestSupplier) {
+    return Mono.defer(
+        () -> {
+          Mono<TokenInfo> waiter =
+              getOrCreateSharedRequest(tokenEndpoint, tokenKey, requestSupplier, FOREGROUND)
+                  .publisher();
+          if (tokenFetchProperties
+                  .requestWaitTimeout()
+                  .compareTo(tokenFetchProperties.overallTimeout())
+              < 0) {
+            waiter =
+                waiter
+                    .timeout(tokenFetchProperties.requestWaitTimeout())
+                    .onErrorMap(
+                        TimeoutException.class,
+                        error -> {
+                          metrics.record(Outcome.DEADLINE, FOREGROUND);
+                          return new ResponseStatusException(
+                              HttpStatus.GATEWAY_TIMEOUT,
+                              "Timed out waiting for a token from " + tokenEndpoint,
+                              error);
+                        });
+          }
+          metrics.waiterStarted();
+          return waiter
+              .onErrorMap(TokenRequestBuildException.class, Throwable::getCause)
+              .doFinally(signal -> metrics.waiterFinished());
         });
+  }
+
+  /**
+   * Atomically joins the current per-key fetch or installs a new cached publisher. Eviction removes
+   * the selected publisher, allowing the next caller to install a replacement.
+   */
+  private FetchSelection getOrCreateSharedRequest(
+      String tokenEndpoint, String tokenKey, Supplier<TokenRequest> requestSupplier, Mode mode) {
+    Mono<TokenInfo> candidate =
+        createInFlightRequest(tokenEndpoint, tokenKey, requestSupplier, mode);
+    return tokenCache.getOrCreateFetch(tokenKey, candidate);
+  }
+
+  /**
+   * Builds a shared fetch that downstream waiter cancellation cannot stop. Terminal cleanup runs
+   * before {@code cache()} replays signals to waiters; {@code doFinally} is the guarded fallback
+   * for cancellation paths that do not invoke {@code doOnTerminate}.
+   */
+  private Mono<TokenInfo> createInFlightRequest(
+      String tokenEndpoint, String tokenKey, Supplier<TokenRequest> requestSupplier, Mode mode) {
+    AtomicReference<Mono<TokenInfo>> self = new AtomicReference<>();
+    AtomicBoolean cleanedUp = new AtomicBoolean();
+    Runnable cleanup =
+        () -> {
+          if (cleanedUp.compareAndSet(false, true)) {
+            if (mode == BACKGROUND) {
+              recentBackgroundRefreshAttempts.put(tokenKey, Boolean.TRUE);
+            }
+            tokenCache.completeFetch(tokenKey, self.get());
+            metrics.fetchFinished();
+          }
+        };
+    Mono<TokenInfo> request =
+        Mono.fromCallable(requestSupplier::get)
+            .onErrorMap(TokenRequestBuildException::new)
+            .subscribeOn(Schedulers.boundedElastic())
+            .flatMap(
+                tokenRequest ->
+                    getAccessTokenQuery(
+                        tokenEndpoint,
+                        tokenKey,
+                        tokenRequest.formData(),
+                        tokenRequest.basicAuthHeader(),
+                        mode))
+            .timeout(tokenFetchProperties.overallTimeout())
+            .onErrorMap(
+                TimeoutException.class,
+                error ->
+                    new ResponseStatusException(
+                        HttpStatus.GATEWAY_TIMEOUT,
+                        "Timeout occurred while fetching token from " + tokenEndpoint,
+                        error))
+            .doOnNext(
+                tokenInfo -> tokenCache.saveTokenIfFetchMatches(tokenKey, self.get(), tokenInfo))
+            .doOnSubscribe(
+                ignored -> {
+                  log.debug("Creating new token request for key: {}", tokenKey);
+                  metrics.fetchStarted();
+                })
+            .doOnNext(ignored -> metrics.record(Outcome.SUCCESS, mode))
+            .doOnError(error -> metrics.record(classifyOutcome(error, mode), mode))
+            .doOnTerminate(cleanup)
+            .doFinally(signal -> cleanup.run())
+            .cache();
+    self.set(request);
+    return request;
   }
 
   private Mono<TokenInfo> getAccessTokenQuery(
       String tokenEndpoint,
       String tokenKey,
       MultiValueMap<String, String> formData,
-      String basicAuthHeader) {
+      String basicAuthHeader,
+      Mode mode) {
 
     return oauthTokenUtilWebClient
         .post()
@@ -236,42 +416,22 @@ public class TokenFetchService {
         .body(BodyInserters.fromFormData(formData))
         .retrieve()
         .onStatus(
-            HttpStatusCode::is4xxClientError,
-            response -> {
-              logClientErrorResponse(response, tokenKey);
-              return Mono.error(
-                  new ResponseStatusException(
-                      HttpStatus.UNAUTHORIZED,
-                      "Failed to retrieve token from "
-                          + tokenEndpoint
-                          + ", original status: "
-                          + response.statusCode()));
-            })
-        .onStatus(
-            HttpStatusCode::is5xxServerError,
-            response -> {
-              logClientErrorResponse(response, tokenKey);
-              return Mono.error(
-                  new ResponseStatusException(
-                      HttpStatus.UNAUTHORIZED,
-                      "Failed to retrieve token from "
-                          + tokenEndpoint
-                          + ", original status: "
-                          + response.statusCode()));
-            })
+            HttpStatusCode::isError, response -> handleIdpError(response, tokenEndpoint, tokenKey))
         .bodyToMono(TokenInfo.class)
-        .timeout(Duration.ofSeconds(15))
+        .flatMap(
+            tokenInfo ->
+                StringUtils.isNotBlank(tokenInfo.getAccessToken())
+                    ? Mono.just(tokenInfo)
+                    : Mono.error(
+                        new ResponseStatusException(
+                            HttpStatus.NOT_ACCEPTABLE,
+                            "Identity provider returned an invalid token response from "
+                                + tokenEndpoint)))
         .switchIfEmpty(
             Mono.error(
                 new ResponseStatusException(
                     HttpStatus.NOT_ACCEPTABLE,
                     "Empty response while fetching token from " + tokenEndpoint)))
-        .onErrorMap(
-            TimeoutException.class,
-            throwable ->
-                new ResponseStatusException(
-                    HttpStatus.GATEWAY_TIMEOUT,
-                    "Timeout occurred while fetching token from " + tokenEndpoint))
         .onErrorMap(
             WebClientResponseException.class,
             ex -> {
@@ -285,46 +445,123 @@ public class TokenFetchService {
             throwable ->
                 new ResponseStatusException(
                     HttpStatus.NOT_ACCEPTABLE,
-                    "Failed while fetching token from "
-                        + tokenEndpoint
-                        + ": "
-                        + throwable.getMessage().replace("bodyType=jumper.model.", "")))
+                    "Identity provider returned an invalid token response from " + tokenEndpoint,
+                    throwable))
         .doOnError(
             throwable ->
-                log.error(
-                    "Error occurred class: {}, msg: {}",
+                log.debug(
+                    "Token fetch attempt failed: {}: {}",
                     throwable.getClass().getSimpleName(),
                     throwable.getMessage()))
         .retryWhen(
-            Retry.backoff(2, Duration.ofMillis(200))
-                .maxBackoff(Duration.ofSeconds(2))
-                .filter(
-                    throwable ->
-                        throwable instanceof ConnectTimeoutException
-                            || throwable.getCause() instanceof SslHandshakeTimeoutException
-                            || throwable.getCause() instanceof PrematureCloseException
-                            || throwable.getCause() instanceof UnknownHostException)
+            Retry.backoff(tokenFetchProperties.maxRetries(), tokenFetchProperties.retryBackoff())
+                .maxBackoff(tokenFetchProperties.maxRetryBackoff())
+                .jitter(0.5)
+                .filter(this::isConnectionFailure)
+                .doBeforeRetry(ignored -> metrics.recordRetry(mode))
                 .onRetryExhaustedThrow(
-                    (retryBackoffSpec, retrySignal) -> {
-                      throw new ResponseStatusException(
-                          HttpStatus.UNAUTHORIZED,
-                          "Failed to connect to "
-                              + tokenEndpoint
-                              + ", cause: "
-                              + retrySignal.failure().getMessage());
-                    }))
-        .doOnNext(tokenInfo -> tokenCache.saveToken(tokenKey, tokenInfo));
+                    (retryBackoffSpec, retrySignal) ->
+                        new TokenFetchUnavailableException(tokenEndpoint, retrySignal.failure())));
   }
 
-  private void logClientErrorResponse(ClientResponse response, String tokenKey) {
-    response
-        .bodyToMono(String.class)
-        .publishOn(Schedulers.boundedElastic())
-        .subscribe(
+  Mono<? extends Throwable> handleIdpError(
+      ClientResponse response, String tokenEndpoint, String tokenKey) {
+    ResponseStatusException error =
+        new ResponseStatusException(
+            HttpStatus.UNAUTHORIZED,
+            "Failed to retrieve token from "
+                + tokenEndpoint
+                + ", original status: "
+                + response.statusCode());
+    if (!log.isDebugEnabled()) {
+      return response
+          .releaseBody()
+          .onErrorResume(
+              bodyError -> {
+                log.debug("Failed to release identity provider error response body", bodyError);
+                return Mono.empty();
+              })
+          .thenReturn(error);
+    }
+
+    return readErrorBody(response)
+        .doOnNext(
             body ->
-                log.warn(
-                    "Client error occurred while getting token for tokenKey {}: {}",
+                log.debug(
+                    "Identity provider error while getting token for tokenKey {}: {}",
                     tokenKey,
-                    body));
+                    body))
+        .thenReturn(error);
+  }
+
+  Mono<String> readErrorBody(ClientResponse response) {
+    int limit = Math.toIntExact(tokenFetchProperties.errorBodyLogLimit().toBytes());
+    ByteArrayOutputStream body = new ByteArrayOutputStream(Math.min(limit, 1024));
+    AtomicReference<Integer> remaining = new AtomicReference<>(limit);
+    return response
+        .bodyToFlux(DataBuffer.class)
+        .doOnNext(
+            dataBuffer -> {
+              try {
+                int bytesToRead = Math.min(dataBuffer.readableByteCount(), remaining.get());
+                if (bytesToRead > 0) {
+                  byte[] bytes = new byte[bytesToRead];
+                  dataBuffer.read(bytes);
+                  body.writeBytes(bytes);
+                  remaining.updateAndGet(value -> value - bytesToRead);
+                }
+              } finally {
+                DataBufferUtils.release(dataBuffer);
+              }
+            })
+        .doOnDiscard(DataBuffer.class, DataBufferUtils::release)
+        .then()
+        .onErrorResume(
+            bodyError -> {
+              log.debug("Failed to read identity provider error response body", bodyError);
+              return Mono.empty();
+            })
+        .then(Mono.fromSupplier(() -> body.toString(StandardCharsets.UTF_8)));
+  }
+
+  private Outcome classifyOutcome(Throwable error, Mode mode) {
+    if (error instanceof TokenRequestBuildException) {
+      return Outcome.REQUEST_BUILD_FAILURE;
+    }
+    if (error instanceof TokenFetchUnavailableException) {
+      return Outcome.RETRY_EXHAUSTED;
+    }
+    if (error instanceof ResponseStatusException responseStatusException) {
+      return switch (responseStatusException.getStatusCode().value()) {
+        case 504 -> Outcome.DEADLINE;
+        default -> Outcome.IDP_ERROR;
+      };
+    }
+    return isConnectionFailure(error) ? Outcome.CONNECT_FAILURE : Outcome.IDP_ERROR;
+  }
+
+  private boolean isConnectionFailure(Throwable error) {
+    Throwable current = error;
+    while (current != null) {
+      if (current instanceof ConnectException
+          || current instanceof ConnectTimeoutException
+          || current instanceof NoRouteToHostException
+          || current instanceof SslHandshakeTimeoutException
+          || current instanceof PrematureCloseException
+          || current instanceof UnknownHostException) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private record TokenRequest(MultiValueMap<String, String> formData, String basicAuthHeader) {}
+
+  private static final class TokenRequestBuildException extends RuntimeException {
+
+    private TokenRequestBuildException(Throwable cause) {
+      super(cause);
+    }
   }
 }

--- a/src/main/java/jumper/service/TokenFetchService.java
+++ b/src/main/java/jumper/service/TokenFetchService.java
@@ -36,6 +36,7 @@ import jumper.service.TokenCacheService.FetchSelection;
 import jumper.service.TokenFetchMetrics.Mode;
 import jumper.service.TokenFetchMetrics.Outcome;
 import jumper.util.BasicAuthUtil;
+import jumper.util.OauthTokenUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -421,7 +422,7 @@ public class TokenFetchService {
         .flatMap(
             tokenInfo ->
                 StringUtils.isNotBlank(tokenInfo.getAccessToken())
-                    ? Mono.just(tokenInfo)
+                    ? Mono.just(applyAccessTokenExpirationFallback(tokenInfo))
                     : Mono.error(
                         new ResponseStatusException(
                             HttpStatus.NOT_ACCEPTABLE,
@@ -462,6 +463,14 @@ public class TokenFetchService {
                 .onRetryExhaustedThrow(
                     (retryBackoffSpec, retrySignal) ->
                         new TokenFetchUnavailableException(tokenEndpoint, retrySignal.failure())));
+  }
+
+  private TokenInfo applyAccessTokenExpirationFallback(TokenInfo tokenInfo) {
+    if (tokenInfo.getExpiration() == null) {
+      OauthTokenUtil.getExpirationFromAccessToken(tokenInfo.getAccessToken())
+          .ifPresent(tokenInfo::setExpiration);
+    }
+    return tokenInfo;
   }
 
   Mono<? extends Throwable> handleIdpError(

--- a/src/main/java/jumper/util/OauthTokenUtil.java
+++ b/src/main/java/jumper/util/OauthTokenUtil.java
@@ -7,7 +7,9 @@ package jumper.util;
 import io.jsonwebtoken.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Date;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 
@@ -31,16 +33,22 @@ public final class OauthTokenUtil {
   }
 
   static String getTokenWithoutSignature(String token) {
-    String fullyProcessedToken = processToken(token);
+    return getRawTokenWithoutSignature(processToken(token));
+  }
 
-    int firstDot = fullyProcessedToken.indexOf(".");
-    int secondDot = fullyProcessedToken.indexOf(".", firstDot + 1);
+  private static String getRawTokenWithoutSignature(String token) {
+    if (token == null) {
+      throw new IllegalArgumentException("Token not provided, but expected");
+    }
+
+    int firstDot = token.indexOf(".");
+    int secondDot = token.indexOf(".", firstDot + 1);
 
     if (secondDot == -1) {
       throw new IllegalArgumentException("Invalid token format");
     }
 
-    return fullyProcessedToken.substring(0, secondDot + 1);
+    return token.substring(0, secondDot + 1);
   }
 
   public static String getClaimFromToken(String token, String claimName) {
@@ -49,16 +57,39 @@ public final class OauthTokenUtil {
 
   public static Jwt<?, Claims> getAllClaimsFromToken(String token) {
     String tokenWithoutSignature = getTokenWithoutSignature(token);
-
-    int firstDot = tokenWithoutSignature.indexOf('.');
-    String unsecuredToken = UNSECURED_HEADER + tokenWithoutSignature.substring(firstDot);
-
     try {
-      return jwtParser.parseUnsecuredClaims(unsecuredToken);
+      return parseClaimsWithoutSignatureValidation(tokenWithoutSignature);
     } catch (Exception e) {
       log.error("Failed to parse token", e);
       throw e;
     }
+  }
+
+  public static Optional<Date> getExpirationFromAccessToken(String accessToken) {
+    if (accessToken == null || accessToken.isBlank()) {
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.ofNullable(
+          parseClaimsWithoutSignatureValidation(getRawTokenWithoutSignature(accessToken))
+              .getPayload()
+              .getExpiration());
+    } catch (ClaimJwtException error) {
+      return Optional.ofNullable(error.getClaims().getExpiration());
+    } catch (JwtException | IllegalArgumentException error) {
+      log.debug(
+          "Access token has no parseable JWT expiration claim: {}",
+          error.getClass().getSimpleName());
+      return Optional.empty();
+    }
+  }
+
+  private static Jwt<?, Claims> parseClaimsWithoutSignatureValidation(
+      String tokenWithoutSignature) {
+    int firstDot = tokenWithoutSignature.indexOf('.');
+    String unsecuredToken = UNSECURED_HEADER + tokenWithoutSignature.substring(firstDot);
+    return jwtParser.parseUnsecuredClaims(unsecuredToken);
   }
 
   private static @NonNull String processToken(String token) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -201,9 +201,20 @@ jumper:
         # - TLS_ECDHE_ECDSA_WITH_AES_256_CCM # unsupported by used jvm 1.2
         # - TLS_AES_128_CCM_SHA256 # unsupported by used jvm 1.3
   tokencache:
-    ttlOffset: 10
     maxSize: 10000
     expireAfterWriteMinutes: 30
+  oauth:
+    token-fetch:
+      connect-timeout: ${JUMPER_OAUTH_TOKEN_FETCH_CONNECT_TIMEOUT:${spring.cloud.oauth.connect-timeout:2s}}
+      overall-timeout: ${JUMPER_OAUTH_TOKEN_FETCH_OVERALL_TIMEOUT:10s}
+      request-wait-timeout: ${JUMPER_OAUTH_TOKEN_FETCH_REQUEST_WAIT_TIMEOUT:4s}
+      max-retries: ${JUMPER_OAUTH_TOKEN_FETCH_MAX_RETRIES:1}
+      retry-backoff: ${JUMPER_OAUTH_TOKEN_FETCH_RETRY_BACKOFF:200ms}
+      max-retry-backoff: ${JUMPER_OAUTH_TOKEN_FETCH_MAX_RETRY_BACKOFF:1s}
+      error-body-log-limit: ${JUMPER_OAUTH_TOKEN_FETCH_ERROR_BODY_LOG_LIMIT:8KB}
+      refresh-ahead: ${JUMPER_OAUTH_TOKEN_FETCH_REFRESH_AHEAD:30s}
+      min-serve: ${JUMPER_OAUTH_TOKEN_FETCH_MIN_SERVE:${jumper.tokencache.ttlOffset:10}s}
+      minimum-background-refresh-interval: ${JUMPER_OAUTH_TOKEN_FETCH_MINIMUM_BACKGROUND_REFRESH_INTERVAL:5s}
   warmup:
     enabled: false
     timeout: 15s

--- a/src/test/java/jumper/BaseSteps.java
+++ b/src/test/java/jumper/BaseSteps.java
@@ -89,6 +89,11 @@ public class BaseSteps {
     requestExchange.expectStatus().isEqualTo(arg0);
   }
 
+  @And("response contains Retry-After header")
+  public void responseContainsRetryAfterHeader() {
+    requestExchange.expectHeader().valueEquals("Retry-After", "30");
+  }
+
   @And("horizon receives a {int} status code")
   public void horizonReceivesAStatusCode(int arg0) {
     requestExchange.expectStatus().isEqualTo(arg0);
@@ -252,6 +257,11 @@ public class BaseSteps {
     mockIrisServer.createExpectationExternalTokenNoExpiresInMultipleCalls(id, 5);
   }
 
+  @And("IDP set to provide a short-lived token then fail refreshes")
+  public void idpSetToProvideShortLivedTokenThenFailRefreshes() {
+    mockIrisServer.createExpectationShortLivedExternalTokenThenFail(id);
+  }
+
   @And("IDP set to provide alternative token without expires_in allowing multiple calls")
   public void idpSetToProvideAlternativeTokenWithoutExpiresInMultipleCalls() {
     mockIrisServer.createExpectationAlternativeTokenNoExpiresInMultipleCalls(id, 5);
@@ -260,6 +270,16 @@ public class BaseSteps {
   @And("IDP token endpoint was called exactly {int} times")
   public void idpTokenEndpointWasCalledTimes(int expectedCount) {
     mockIrisServer.verifyTokenEndpointCallCount(expectedCount);
+  }
+
+  @And("IDP token endpoint eventually receives exactly {int} calls")
+  public void idpTokenEndpointEventuallyReceivesCalls(int expectedCount) {
+    mockIrisServer.awaitTokenEndpointCallCount(expectedCount);
+  }
+
+  @And("IDP token endpoint call count remains exactly {int}")
+  public void idpTokenEndpointCallCountRemains(int expectedCount) {
+    mockIrisServer.verifyTokenEndpointCallCountRemains(expectedCount);
   }
 
   @When("consumer calls the proxy route")

--- a/src/test/java/jumper/config/OauthTokenFetchPropertiesTest.java
+++ b/src/test/java/jumper/config/OauthTokenFetchPropertiesTest.java
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+import org.springframework.util.unit.DataSize;
+
+class OauthTokenFetchPropertiesTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner().withUserConfiguration(PropertiesConfiguration.class);
+
+  @Test
+  void bindsConfiguredRefreshPolicy() {
+    contextRunner
+        .withPropertyValues(
+            "jumper.oauth.token-fetch.refresh-ahead=45s",
+            "jumper.oauth.token-fetch.min-serve=15s",
+            "jumper.oauth.token-fetch.minimum-background-refresh-interval=7s",
+            "jumper.oauth.token-fetch.connect-timeout=1500ms",
+            "jumper.oauth.token-fetch.overall-timeout=6s",
+            "jumper.oauth.token-fetch.request-wait-timeout=4s",
+            "jumper.oauth.token-fetch.max-retries=1",
+            "jumper.oauth.token-fetch.retry-backoff=250ms",
+            "jumper.oauth.token-fetch.max-retry-backoff=900ms",
+            "jumper.oauth.token-fetch.error-body-log-limit=4KB")
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              OauthTokenFetchProperties properties =
+                  context.getBean(OauthTokenFetchProperties.class);
+              assertThat(properties.connectTimeout()).isEqualTo(Duration.ofMillis(1500));
+              assertThat(properties.overallTimeout()).isEqualTo(Duration.ofSeconds(6));
+              assertThat(properties.requestWaitTimeout()).isEqualTo(Duration.ofSeconds(4));
+              assertThat(properties.maxRetries()).isOne();
+              assertThat(properties.retryBackoff()).isEqualTo(Duration.ofMillis(250));
+              assertThat(properties.maxRetryBackoff()).isEqualTo(Duration.ofMillis(900));
+              assertThat(properties.errorBodyLogLimit()).isEqualTo(DataSize.ofKilobytes(4));
+              assertThat(properties.refreshAhead()).isEqualTo(Duration.ofSeconds(45));
+              assertThat(properties.minServe()).isEqualTo(Duration.ofSeconds(15));
+              assertThat(properties.minimumBackgroundRefreshInterval())
+                  .isEqualTo(Duration.ofSeconds(7));
+            });
+  }
+
+  @Test
+  void rejectsRefreshWindowAtMinimumServeThreshold() {
+    contextRunner
+        .withPropertyValues(validProperties())
+        .withPropertyValues("jumper.oauth.token-fetch.refresh-ahead=10s")
+        .run(
+            context ->
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .hasMessageContaining("refreshAhead must exceed minServe"));
+  }
+
+  @Test
+  void rejectsRequestWaitTimeoutAboveOverallTimeout() {
+    contextRunner
+        .withPropertyValues(validProperties())
+        .withPropertyValues("jumper.oauth.token-fetch.request-wait-timeout=6s")
+        .run(
+            context ->
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .hasMessageContaining("requestWaitTimeout must not exceed overallTimeout"));
+  }
+
+  @Test
+  void rejectsNonPositiveConnectTimeout() {
+    contextRunner
+        .withPropertyValues(validProperties())
+        .withPropertyValues("jumper.oauth.token-fetch.connect-timeout=0ms")
+        .run(
+            context ->
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .hasMessageContaining("connectTimeout"));
+  }
+
+  @Test
+  void rejectsNegativeRetryCount() {
+    contextRunner
+        .withPropertyValues(validProperties())
+        .withPropertyValues("jumper.oauth.token-fetch.max-retries=-1")
+        .run(
+            context ->
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .hasMessageContaining("maxRetries"));
+  }
+
+  @Test
+  void rejectsErrorBodyLogLimitAbove64Kilobytes() {
+    contextRunner
+        .withPropertyValues(validProperties())
+        .withPropertyValues("jumper.oauth.token-fetch.error-body-log-limit=65KB")
+        .run(
+            context ->
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .hasMessageContaining("errorBodyLogLimit must be between 1B and 64KB"));
+  }
+
+  @Test
+  void accepts64KilobyteErrorBodyLogLimit() {
+    contextRunner
+        .withPropertyValues(validProperties())
+        .withPropertyValues("jumper.oauth.token-fetch.error-body-log-limit=64KB")
+        .run(context -> assertThat(context).hasNotFailed());
+  }
+
+  @Test
+  void rejectsZeroErrorBodyLogLimit() {
+    contextRunner
+        .withPropertyValues(validProperties())
+        .withPropertyValues("jumper.oauth.token-fetch.error-body-log-limit=0B")
+        .run(
+            context ->
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .hasMessageContaining("errorBodyLogLimit must be between 1B and 64KB"));
+  }
+
+  @Test
+  void legacyTtlOffsetRemainsFallbackForMinimumServe() {
+    new ApplicationContextRunner()
+        .withInitializer(new ConfigDataApplicationContextInitializer())
+        .withPropertyValues("jumper.tokencache.ttlOffset=17")
+        .withUserConfiguration(PropertiesConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context.getBean(OauthTokenFetchProperties.class).minServe())
+                  .isEqualTo(Duration.ofSeconds(17));
+            });
+  }
+
+  @Test
+  void newMinimumServeSettingOverridesLegacyTtlOffset() {
+    new ApplicationContextRunner()
+        .withInitializer(new ConfigDataApplicationContextInitializer())
+        .withPropertyValues(
+            "jumper.tokencache.ttlOffset=17", "JUMPER_OAUTH_TOKEN_FETCH_MIN_SERVE=12s")
+        .withUserConfiguration(PropertiesConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context.getBean(OauthTokenFetchProperties.class).minServe())
+                  .isEqualTo(Duration.ofSeconds(12));
+            });
+  }
+
+  @Test
+  void environmentVariablesOverrideApplicationDefaults() {
+    new ApplicationContextRunner()
+        .withInitializer(new ConfigDataApplicationContextInitializer())
+        .withInitializer(
+            context ->
+                context
+                    .getEnvironment()
+                    .getPropertySources()
+                    .addFirst(
+                        new SystemEnvironmentPropertySource(
+                            "testEnvironment",
+                            Map.of(
+                                "JUMPER_OAUTH_TOKEN_FETCH_CONNECT_TIMEOUT", "750ms",
+                                "JUMPER_OAUTH_TOKEN_FETCH_MAX_RETRIES", "0",
+                                "JUMPER_OAUTH_TOKEN_FETCH_REFRESH_AHEAD", "40s"))))
+        .withUserConfiguration(PropertiesConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              OauthTokenFetchProperties properties =
+                  context.getBean(OauthTokenFetchProperties.class);
+              assertThat(properties.connectTimeout()).isEqualTo(Duration.ofMillis(750));
+              assertThat(properties.maxRetries()).isZero();
+              assertThat(properties.refreshAhead()).isEqualTo(Duration.ofSeconds(40));
+            });
+  }
+
+  private String[] validProperties() {
+    return new String[] {
+      "jumper.oauth.token-fetch.connect-timeout=2s",
+      "jumper.oauth.token-fetch.overall-timeout=5s",
+      "jumper.oauth.token-fetch.request-wait-timeout=4s",
+      "jumper.oauth.token-fetch.max-retries=1",
+      "jumper.oauth.token-fetch.retry-backoff=200ms",
+      "jumper.oauth.token-fetch.max-retry-backoff=1s",
+      "jumper.oauth.token-fetch.error-body-log-limit=8KB",
+      "jumper.oauth.token-fetch.refresh-ahead=30s",
+      "jumper.oauth.token-fetch.min-serve=10s",
+      "jumper.oauth.token-fetch.minimum-background-refresh-interval=5s"
+    };
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @EnableConfigurationProperties(OauthTokenFetchProperties.class)
+  static class PropertiesConfiguration {}
+}

--- a/src/test/java/jumper/filter/ResponseFilterTest.java
+++ b/src/test/java/jumper/filter/ResponseFilterTest.java
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.filter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.micrometer.tracing.Tracer;
+import jumper.Constants;
+import jumper.service.TokenCacheService;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import reactor.core.publisher.Mono;
+
+class ResponseFilterTest {
+
+  private static final String TOKEN_KEY = "token-key";
+
+  @Test
+  void infrastructureFailuresDoNotEvictToken() {
+    TokenCacheService tokenCache = mock(TokenCacheService.class);
+    ResponseFilter filter = new ResponseFilter(mock(Tracer.class), tokenCache);
+
+    filterResponse(filter, HttpStatus.SERVICE_UNAVAILABLE);
+    filterResponse(filter, HttpStatus.GATEWAY_TIMEOUT);
+    filterResponse(filter, HttpStatus.BAD_GATEWAY);
+
+    verify(tokenCache, never()).evictToken(TOKEN_KEY);
+  }
+
+  @Test
+  void authenticationFailuresStillEvictToken() {
+    TokenCacheService tokenCache = mock(TokenCacheService.class);
+    ResponseFilter filter = new ResponseFilter(mock(Tracer.class), tokenCache);
+
+    filterResponse(filter, HttpStatus.UNAUTHORIZED);
+    filterResponse(filter, HttpStatus.FORBIDDEN);
+
+    verify(tokenCache, org.mockito.Mockito.times(2)).evictToken(TOKEN_KEY);
+  }
+
+  private void filterResponse(ResponseFilter filter, HttpStatus status) {
+    MockServerWebExchange exchange =
+        MockServerWebExchange.from(MockServerHttpRequest.get("/provider").build());
+    exchange.getAttributes().put(Constants.GATEWAY_ATTRIBUTE_TOKEN_CACHE_KEY, TOKEN_KEY);
+    GatewayFilterChain chain =
+        currentExchange -> {
+          currentExchange.getResponse().setStatusCode(status);
+          return Mono.empty();
+        };
+
+    filter.apply(new ResponseFilter.Config()).filter(exchange, chain).block();
+  }
+}

--- a/src/test/java/jumper/mocks/MockIrisServer.java
+++ b/src/test/java/jumper/mocks/MockIrisServer.java
@@ -12,16 +12,19 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static jumper.config.Config.*;
 import static jumper.util.JumperConfigUtil.addIdSuffix;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.http.Fault;
+import java.time.Duration;
 import java.util.Base64;
 import jumper.model.TokenInfo;
 import jumper.util.AccessToken;
 import jumper.util.ObjectMapperUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
 import tools.jackson.core.JacksonException;
 
 @Slf4j
@@ -411,6 +414,45 @@ public class MockIrisServer {
                     .withFixedDelay(100)));
   }
 
+  public void createExpectationShortLivedExternalTokenThenFail(String id) {
+    TokenInfo tokenInfo = new TokenInfo();
+    tokenInfo.setAccessToken(getToken(CONSUMER_EXTERNAL_CONFIGURED));
+    tokenInfo.setExpiresIn(20);
+    tokenInfo.setTokenType("bearer");
+
+    String tokenInfoJson;
+    try {
+      tokenInfoJson = ObjectMapperUtil.getInstance().writeValueAsString(tokenInfo);
+    } catch (JacksonException error) {
+      throw new IllegalStateException("Failed to serialize test token", error);
+    }
+
+    String authorization =
+        "Basic "
+            + Base64.getEncoder()
+                .encodeToString(
+                    (addIdSuffix("external_configured", id) + ":" + "secret").getBytes());
+    server.stubFor(
+        post(urlPathEqualTo("/external"))
+            .inScenario("background-refresh-failure")
+            .whenScenarioStateIs(STARTED)
+            .withRequestBody(equalTo("grant_type=client_credentials"))
+            .withHeader("Authorization", equalTo(authorization))
+            .willSetStateTo("refresh-fails")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBody(tokenInfoJson)));
+    server.stubFor(
+        post(urlPathEqualTo("/external"))
+            .inScenario("background-refresh-failure")
+            .whenScenarioStateIs("refresh-fails")
+            .withRequestBody(equalTo("grant_type=client_credentials"))
+            .withHeader("Authorization", equalTo(authorization))
+            .willReturn(aResponse().withStatus(500)));
+  }
+
   public void createExpectationExternalTokenNoExpiresInMultipleCalls(String id, int maxCalls) {
     String tokenInfoJson = getTokenInfoJsonWithoutExpiresIn(CONSUMER_EXTERNAL_CONFIGURED);
 
@@ -459,6 +501,25 @@ public class MockIrisServer {
 
   public void verifyTokenEndpointCallCount(int expectedCount) {
     server.verify(exactly(expectedCount), postRequestedFor(urlPathEqualTo("/external")));
+  }
+
+  public void awaitTokenEndpointCallCount(int expectedCount) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(
+            () ->
+                server.verify(
+                    exactly(expectedCount), postRequestedFor(urlPathEqualTo("/external"))));
+  }
+
+  public void verifyTokenEndpointCallCountRemains(int expectedCount) {
+    Awaitility.await()
+        .during(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(1))
+        .untilAsserted(
+            () ->
+                server.verify(
+                    exactly(expectedCount), postRequestedFor(urlPathEqualTo("/external"))));
   }
 
   private String getTokenInfoJsonWithoutExpiresIn(String client) {

--- a/src/test/java/jumper/service/TokenCacheServiceTest.java
+++ b/src/test/java/jumper/service/TokenCacheServiceTest.java
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Date;
+import jumper.config.OauthTokenFetchProperties;
+import jumper.model.TokenInfo;
+import jumper.model.config.OauthCredentials;
+import jumper.service.TokenCacheService.Freshness;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.util.unit.DataSize;
+import reactor.core.publisher.Mono;
+
+class TokenCacheServiceTest {
+
+  private static final String TOKEN_KEY = "token-key";
+  private static final Instant NOW = Instant.parse("2026-08-19T12:00:00Z");
+
+  private TokenCacheService tokenCacheService;
+
+  @BeforeEach
+  void setUp() {
+    tokenCacheService = createTokenCacheService();
+  }
+
+  @Test
+  void lookupInsideRefreshWindow_returnsTokenWithoutEvictingIt() {
+    TokenInfo token = tokenExpiringIn(Duration.ofSeconds(20));
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    var firstLookup = tokenCacheService.lookup(TOKEN_KEY);
+    var secondLookup = tokenCacheService.lookup(TOKEN_KEY);
+
+    assertThat(firstLookup.token()).isSameAs(token);
+    assertThat(firstLookup.freshness()).isEqualTo(Freshness.NEEDS_REFRESH);
+    assertThat(secondLookup.token()).isSameAs(token);
+  }
+
+  @Test
+  void lookupTokenWithoutExpiry_returnsFreshServableToken() {
+    TokenInfo token = new TokenInfo();
+    token.setAccessToken("access-token");
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    var lookup = tokenCacheService.lookup(TOKEN_KEY);
+
+    assertThat(lookup.servable()).isTrue();
+    assertThat(lookup.needsRefresh()).isFalse();
+    assertThat(lookup.token()).isSameAs(token);
+  }
+
+  @Test
+  void lookupAboveRefreshWindow_returnsFreshToken() {
+    TokenInfo token = tokenExpiringIn(Duration.ofSeconds(60));
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).freshness()).isEqualTo(Freshness.FRESH);
+  }
+
+  @Test
+  void lookupAtOrBelowMinimumServeThreshold_returnsNotServableToken() {
+    TokenInfo token = tokenExpiringIn(Duration.ofSeconds(5));
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    var lookup = tokenCacheService.lookup(TOKEN_KEY);
+
+    assertThat(lookup.servable()).isFalse();
+    assertThat(lookup.token()).isNull();
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).token()).isNull();
+  }
+
+  @Test
+  void lookupExpiredToken_returnsNotServableToken() {
+    TokenInfo token = tokenExpiringIn(Duration.ofSeconds(-1));
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).servable()).isFalse();
+  }
+
+  @Test
+  void lookupAtRefreshAheadBoundary_returnsNeedsRefresh() {
+    TokenInfo token = tokenExpiringIn(Duration.ofSeconds(30));
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).freshness()).isEqualTo(Freshness.NEEDS_REFRESH);
+  }
+
+  @Test
+  void lookupJustAboveRefreshAheadBoundary_returnsFresh() {
+    TokenInfo token = tokenExpiringIn(Duration.ofMillis(30_001));
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).freshness()).isEqualTo(Freshness.FRESH);
+  }
+
+  @Test
+  void lookupAtMinimumServeBoundary_returnsNotServable() {
+    TokenInfo token = tokenExpiringIn(Duration.ofSeconds(10));
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).servable()).isFalse();
+  }
+
+  @Test
+  void lookupJustAboveMinimumServeBoundary_returnsNeedsRefresh() {
+    TokenInfo token = tokenExpiringIn(Duration.ofMillis(10_001));
+    tokenCacheService.saveToken(TOKEN_KEY, token);
+
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).freshness()).isEqualTo(Freshness.NEEDS_REFRESH);
+  }
+
+  @Test
+  void refreshBeforeEviction_isRemovedByLaterEviction() {
+    TokenInfo refreshedToken = tokenExpiringIn(Duration.ofMinutes(5));
+    Mono<TokenInfo> fetch = Mono.just(refreshedToken);
+    assertThat(tokenCacheService.getOrCreateFetch(TOKEN_KEY, fetch).created()).isTrue();
+
+    assertThat(tokenCacheService.saveTokenIfFetchMatches(TOKEN_KEY, fetch, refreshedToken))
+        .isTrue();
+    tokenCacheService.completeFetch(TOKEN_KEY, fetch);
+    tokenCacheService.evictToken(TOKEN_KEY);
+
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).servable()).isFalse();
+    assertThat(tokenCacheService.activeFetchCount()).isZero();
+  }
+
+  @Test
+  void evictionBeforeRefresh_discardsOlderRefreshResult() {
+    tokenCacheService.saveToken(TOKEN_KEY, tokenExpiringIn(Duration.ofMinutes(5)));
+    Mono<TokenInfo> oldFetch = Mono.never();
+    tokenCacheService.getOrCreateFetch(TOKEN_KEY, oldFetch);
+
+    tokenCacheService.evictToken(TOKEN_KEY);
+    boolean saved =
+        tokenCacheService.saveTokenIfFetchMatches(
+            TOKEN_KEY, oldFetch, tokenExpiringIn(Duration.ofMinutes(5)));
+    tokenCacheService.completeFetch(TOKEN_KEY, oldFetch);
+
+    assertThat(saved).isFalse();
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).servable()).isFalse();
+    assertThat(tokenCacheService.activeFetchCount()).isZero();
+  }
+
+  @Test
+  void fetchStartedAfterEviction_canPopulateCacheWhileOlderFetchCannot() {
+    Mono<TokenInfo> oldFetch = Mono.never();
+    tokenCacheService.getOrCreateFetch(TOKEN_KEY, oldFetch);
+    tokenCacheService.evictToken(TOKEN_KEY);
+    TokenInfo newToken = tokenExpiringIn(Duration.ofMinutes(5));
+    Mono<TokenInfo> newFetch = Mono.just(newToken);
+    tokenCacheService.getOrCreateFetch(TOKEN_KEY, newFetch);
+
+    assertThat(
+            tokenCacheService.saveTokenIfFetchMatches(
+                TOKEN_KEY, oldFetch, tokenExpiringIn(Duration.ofMinutes(5))))
+        .isFalse();
+    assertThat(tokenCacheService.saveTokenIfFetchMatches(TOKEN_KEY, newFetch, newToken)).isTrue();
+    tokenCacheService.completeFetch(TOKEN_KEY, oldFetch);
+    assertThat(tokenCacheService.activeFetchCount()).isOne();
+    tokenCacheService.completeFetch(TOKEN_KEY, newFetch);
+
+    assertThat(tokenCacheService.lookup(TOKEN_KEY).token()).isSameAs(newToken);
+    assertThat(tokenCacheService.activeFetchCount()).isZero();
+    tokenCacheService.evictToken(TOKEN_KEY);
+    assertThat(tokenCacheService.activeFetchCount()).isZero();
+  }
+
+  @Test
+  void concurrentSelection_reusesExistingFetch() {
+    Mono<TokenInfo> first = Mono.never();
+    Mono<TokenInfo> second = Mono.never();
+
+    var created = tokenCacheService.getOrCreateFetch(TOKEN_KEY, first);
+    var reused = tokenCacheService.getOrCreateFetch(TOKEN_KEY, second);
+
+    assertThat(created.publisher()).isSameAs(first);
+    assertThat(created.created()).isTrue();
+    assertThat(reused.publisher()).isSameAs(first);
+    assertThat(reused.created()).isFalse();
+  }
+
+  @Test
+  void oauthCacheKeySeparatesUsersSharingClientCredentials() {
+    OauthCredentials first = passwordCredentials("first-user", "first-password");
+    OauthCredentials second = passwordCredentials("second-user", "second-password");
+
+    assertThat(tokenCacheService.generateTokenCacheKey("https://idp.example.com/token", first))
+        .isNotEqualTo(
+            tokenCacheService.generateTokenCacheKey("https://idp.example.com/token", second));
+  }
+
+  @Test
+  void oauthCacheKeyIncludesEveryRequestIdentityField() {
+    OauthCredentials base = passwordCredentials("user", "password");
+    String baseKey = tokenCacheService.generateTokenCacheKey("https://idp.example.com/token", base);
+
+    OauthCredentials changedGrant = passwordCredentials("user", "password");
+    changedGrant.setGrantType("refresh_token");
+    changedGrant.setRefreshToken("refresh-token");
+    OauthCredentials changedKey = passwordCredentials("user", "password");
+    changedKey.setClientKey("client-key");
+    OauthCredentials changedScope = passwordCredentials("user", "password");
+    changedScope.setScopes("different-scope");
+
+    assertThat(
+            tokenCacheService.generateTokenCacheKey("https://idp.example.com/token", changedGrant))
+        .isNotEqualTo(baseKey);
+    assertThat(tokenCacheService.generateTokenCacheKey("https://idp.example.com/token", changedKey))
+        .isNotEqualTo(baseKey);
+    assertThat(
+            tokenCacheService.generateTokenCacheKey("https://idp.example.com/token", changedScope))
+        .isNotEqualTo(baseKey);
+    assertThat(baseKey).doesNotContain("user", "password", "client-secret");
+  }
+
+  @Test
+  void equivalentClientCredentialsRequestsShareCacheKey() {
+    OauthCredentials credentials = new OauthCredentials();
+    credentials.setClientId("client");
+    credentials.setClientSecret("secret");
+    credentials.setScopes("scope");
+    credentials.setGrantType("client_credentials");
+    credentials.setTokenRequest("basic");
+
+    assertThat(
+            tokenCacheService.generateTokenCacheKey("https://idp.example.com/token", credentials))
+        .isEqualTo(
+            tokenCacheService.generateTokenCacheKey(
+                "https://idp.example.com/token", "client", "secret", "scope"));
+  }
+
+  private TokenCacheService createTokenCacheService() {
+    CacheManager cacheManager = mock(CacheManager.class);
+    when(cacheManager.getCache("cache-token-info"))
+        .thenReturn(new ConcurrentMapCache("cache-token-info"));
+    return new TokenCacheService(
+        cacheManager,
+        new OauthTokenFetchProperties(
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(5),
+            Duration.ofSeconds(5),
+            1,
+            Duration.ofMillis(200),
+            Duration.ofSeconds(1),
+            DataSize.ofKilobytes(8),
+            Duration.ofSeconds(30),
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(5)),
+        Clock.fixed(NOW, ZoneOffset.UTC));
+  }
+
+  private TokenInfo tokenExpiringIn(Duration duration) {
+    TokenInfo token = new TokenInfo();
+    token.setAccessToken("access-token");
+    token.setExpiration(Date.from(NOW.plus(duration)));
+    return token;
+  }
+
+  private OauthCredentials passwordCredentials(String username, String password) {
+    OauthCredentials credentials = new OauthCredentials();
+    credentials.setClientId("shared-client");
+    credentials.setClientSecret("client-secret");
+    credentials.setUsername(username);
+    credentials.setPassword(password);
+    credentials.setScopes("scope");
+    credentials.setGrantType("password");
+    return credentials;
+  }
+}

--- a/src/test/java/jumper/service/TokenFetchServiceTest.java
+++ b/src/test/java/jumper/service/TokenFetchServiceTest.java
@@ -5,20 +5,54 @@
 package jumper.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import com.github.benmanes.caffeine.cache.Ticker;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ConnectTimeoutException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Optional;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import jumper.config.OauthTokenFetchProperties;
+import jumper.exception.TokenFetchUnavailableException;
 import jumper.model.TokenInfo;
 import jumper.model.config.JumperConfig;
+import jumper.model.config.OauthCredentials;
+import jumper.service.TokenCacheService.FetchSelection;
+import jumper.service.TokenCacheService.Freshness;
+import jumper.service.TokenCacheService.TokenLookup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
 import reactor.test.StepVerifier;
 
 class TokenFetchServiceTest {
@@ -31,6 +65,8 @@ class TokenFetchServiceTest {
   private TokenCacheService tokenCacheService;
   private TokenGeneratorService tokenGeneratorService;
   private TokenFetchService tokenFetchService;
+  private SimpleMeterRegistry meterRegistry;
+  private TokenFetchMetrics tokenFetchMetrics;
 
   private AtomicInteger idpCallCount;
 
@@ -38,20 +74,49 @@ class TokenFetchServiceTest {
   void setUp() {
     tokenCacheService = mock(TokenCacheService.class);
     tokenGeneratorService = mock(TokenGeneratorService.class);
+    meterRegistry = new SimpleMeterRegistry();
+    tokenFetchMetrics = new TokenFetchMetrics(meterRegistry);
     idpCallCount = new AtomicInteger(0);
 
     when(tokenCacheService.generateTokenCacheKey(anyString(), anyString(), anyString(), any()))
         .thenReturn(TOKEN_CACHE_KEY);
+    when(tokenCacheService.lookup(anyString()))
+        .thenReturn(new TokenLookup(null, Freshness.NOT_SERVABLE));
+    ConcurrentHashMap<String, Mono<TokenInfo>> activeFetches = new ConcurrentHashMap<>();
+    when(tokenCacheService.getOrCreateFetch(anyString(), any()))
+        .thenAnswer(
+            invocation -> {
+              String tokenKey = invocation.getArgument(0);
+              Mono<TokenInfo> candidate = invocation.getArgument(1);
+              boolean[] created = {false};
+              Mono<TokenInfo> selected =
+                  activeFetches.computeIfAbsent(
+                      tokenKey,
+                      ignored -> {
+                        created[0] = true;
+                        return candidate;
+                      });
+              return new FetchSelection(selected, created[0]);
+            });
+    when(tokenCacheService.saveTokenIfFetchMatches(anyString(), any(), any()))
+        .thenAnswer(
+            invocation ->
+                activeFetches.get(invocation.getArgument(0)) == invocation.getArgument(1));
+    doAnswer(
+            invocation -> {
+              activeFetches.remove(invocation.getArgument(0), invocation.getArgument(1));
+              return null;
+            })
+        .when(tokenCacheService)
+        .completeFetch(anyString(), any());
 
     WebClient webClient = mockWebClient(createTokenInfo(3600), Duration.ZERO);
 
-    tokenFetchService = new TokenFetchService(webClient, tokenCacheService, tokenGeneratorService);
+    tokenFetchService = createTokenFetchService(webClient);
   }
 
   @Test
   void singleRequest_cacheMiss_fetchesTokenFromIdp() {
-    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
-
     StepVerifier.create(
             tokenFetchService.getAccessTokenWithClientCredentials(
                 TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
@@ -62,13 +127,15 @@ class TokenFetchServiceTest {
             })
         .verifyComplete();
 
-    verify(tokenCacheService).saveToken(eq(TOKEN_CACHE_KEY), any(TokenInfo.class));
+    verify(tokenCacheService)
+        .saveTokenIfFetchMatches(eq(TOKEN_CACHE_KEY), any(), any(TokenInfo.class));
   }
 
   @Test
   void singleRequest_cacheHit_doesNotCallIdp() {
     TokenInfo cachedToken = createTokenInfo(3600);
-    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.of(cachedToken));
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.FRESH));
 
     StepVerifier.create(
             tokenFetchService.getAccessTokenWithClientCredentials(
@@ -92,10 +159,12 @@ class TokenFetchServiceTest {
     config.setClientSecret(CLIENT_SECRET);
     TokenInfo cachedToken = createTokenInfo(3600);
     AtomicInteger cacheLookups = new AtomicInteger();
-    when(tokenCacheService.getToken(TOKEN_CACHE_KEY))
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
         .thenAnswer(
             invocation ->
-                cacheLookups.getAndIncrement() == 0 ? Optional.empty() : Optional.of(cachedToken));
+                cacheLookups.getAndIncrement() == 0
+                    ? new TokenLookup(null, Freshness.NOT_SERVABLE)
+                    : new TokenLookup(cachedToken, Freshness.FRESH));
 
     // act
     TokenInfo fetchedToken = tokenFetchService.getInternalMeshAccessToken(config).block();
@@ -111,52 +180,46 @@ class TokenFetchServiceTest {
             CLIENT_ID,
             CLIENT_SECRET,
             null);
-    verify(tokenCacheService).saveToken(TOKEN_CACHE_KEY, fetchedToken);
+    verify(tokenCacheService)
+        .saveTokenIfFetchMatches(eq(TOKEN_CACHE_KEY), any(), same(fetchedToken));
     assertThat(idpCallCount.get()).isOne();
   }
 
   @Test
   void concurrentRequests_cacheMiss_onlySingleIdpCall() {
-    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
-
     // Recreate with a slow IDP response to widen the race window
     WebClient slowWebClient = mockWebClient(createTokenInfo(3600), Duration.ofMillis(200));
-    tokenFetchService =
-        new TokenFetchService(slowWebClient, tokenCacheService, tokenGeneratorService);
+    tokenFetchService = createTokenFetchService(slowWebClient);
 
     int concurrentRequests = 50;
     CountDownLatch startLatch = new CountDownLatch(1);
     CountDownLatch doneLatch = new CountDownLatch(concurrentRequests);
     AtomicInteger successCount = new AtomicInteger(0);
+    List<Throwable> failures = new CopyOnWriteArrayList<>();
 
     for (int i = 0; i < concurrentRequests; i++) {
-      new Thread(
-              () -> {
-                try {
-                  startLatch.await();
-                } catch (InterruptedException e) {
-                  Thread.currentThread().interrupt();
-                  return;
-                }
-                tokenFetchService
-                    .getAccessTokenWithClientCredentials(
-                        TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
-                    .doOnNext(token -> successCount.incrementAndGet())
-                    .block(Duration.ofSeconds(5));
-                doneLatch.countDown();
-              })
-          .start();
+      Thread.startVirtualThread(
+          () -> {
+            try {
+              startLatch.await();
+              tokenFetchService
+                  .getAccessTokenWithClientCredentials(
+                      TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+                  .doOnNext(token -> successCount.incrementAndGet())
+                  .block(Duration.ofSeconds(5));
+            } catch (Throwable error) {
+              failures.add(error);
+            } finally {
+              doneLatch.countDown();
+            }
+          });
     }
 
     // Release all threads simultaneously
     startLatch.countDown();
+    await().atMost(Duration.ofSeconds(10)).until(() -> doneLatch.getCount() == 0);
 
-    try {
-      doneLatch.await();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
-
+    assertThat(failures).isEmpty();
     assertThat(successCount.get()).isEqualTo(concurrentRequests);
     assertThat(idpCallCount.get())
         .as("Expected exactly 1 IDP call for %d concurrent requests", concurrentRequests)
@@ -174,11 +237,8 @@ class TokenFetchServiceTest {
     when(tokenCacheService.generateTokenCacheKey(
             eq("https://zone-b.example.com/token"), anyString(), anyString(), any()))
         .thenReturn(tokenKey2);
-    when(tokenCacheService.getToken(anyString())).thenReturn(Optional.empty());
-
     WebClient slowWebClient = mockWebClient(createTokenInfo(3600), Duration.ofMillis(100));
-    tokenFetchService =
-        new TokenFetchService(slowWebClient, tokenCacheService, tokenGeneratorService);
+    tokenFetchService = createTokenFetchService(slowWebClient);
 
     Mono<TokenInfo> zoneA =
         tokenFetchService.getAccessTokenWithClientCredentials(
@@ -201,8 +261,6 @@ class TokenFetchServiceTest {
 
   @Test
   void afterCompletedRequest_nextRequestMakesNewIdpCall() {
-    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
-
     // First request
     StepVerifier.create(
             tokenFetchService.getAccessTokenWithClientCredentials(
@@ -226,11 +284,9 @@ class TokenFetchServiceTest {
 
   @Test
   void failedIdpCall_cleansUpInFlightEntry_allowsRetry() {
-    when(tokenCacheService.getToken(TOKEN_CACHE_KEY)).thenReturn(Optional.empty());
-
     // Wire up a WebClient that fails first, then succeeds on the next call
     WebClient webClient = mockFailThenSucceedWebClient(createTokenInfo(3600));
-    tokenFetchService = new TokenFetchService(webClient, tokenCacheService, tokenGeneratorService);
+    tokenFetchService = createTokenFetchService(webClient);
 
     // First request fails
     StepVerifier.create(
@@ -247,7 +303,709 @@ class TokenFetchServiceTest {
         .verifyComplete();
   }
 
+  @Test
+  void tokenInsideRefreshWindow_isServedWhileSingleBackgroundRefreshRuns() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    TokenInfo refreshedToken = createTokenInfo(3600);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    tokenFetchService =
+        createTokenFetchService(mockWebClient(refreshedToken, Duration.ofMillis(200)));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectNext(cachedToken)
+        .verifyComplete();
+
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> verifyTokenSaved(refreshedToken));
+    assertThat(idpCallCount).hasValue(1);
+  }
+
+  @Test
+  void concurrentRequestsInsideRefreshWindow_makeSingleIdpCall() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    TokenInfo refreshedToken = createTokenInfo(3600);
+    Sinks.One<TokenInfo> idpResponse = Sinks.one();
+    tokenFetchService = createTokenFetchService(mockWebClient(idpResponse.asMono()));
+
+    int concurrentRequests = 50;
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(concurrentRequests);
+    List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+    for (int index = 0; index < concurrentRequests; index++) {
+      Thread.startVirtualThread(
+          () -> {
+            try {
+              startLatch.await();
+              TokenInfo result =
+                  tokenFetchService
+                      .getAccessTokenWithClientCredentials(
+                          TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+                      .block(Duration.ofSeconds(1));
+              assertThat(result).isSameAs(cachedToken);
+            } catch (Throwable error) {
+              failures.add(error);
+            } finally {
+              doneLatch.countDown();
+            }
+          });
+    }
+
+    startLatch.countDown();
+    await().atMost(Duration.ofSeconds(2)).until(() -> doneLatch.getCount() == 0);
+
+    assertThat(failures).isEmpty();
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(idpCallCount).hasValue(1));
+    assertThat(idpCallCount).hasValue(1);
+    idpResponse.tryEmitValue(refreshedToken).orThrow();
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> verifyTokenSaved(refreshedToken));
+  }
+
+  @Test
+  void oauthCredentialsTokenInsideRefreshWindow_isServedWhileRefreshRuns() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    TokenInfo refreshedToken = createTokenInfo(3600);
+    OauthCredentials credentials = new OauthCredentials();
+    credentials.setClientId(CLIENT_ID);
+    credentials.setClientSecret(CLIENT_SECRET);
+    credentials.setGrantType("client_credentials");
+    when(tokenCacheService.generateTokenCacheKey(TOKEN_ENDPOINT, credentials))
+        .thenReturn(TOKEN_CACHE_KEY);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    tokenFetchService =
+        createTokenFetchService(mockWebClient(refreshedToken, Duration.ofMillis(200)));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithOauthCredentialsObject(TOKEN_ENDPOINT, credentials))
+        .expectNext(cachedToken)
+        .verifyComplete();
+
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> verifyTokenSaved(refreshedToken));
+  }
+
+  @Test
+  void failedBackgroundRefresh_doesNotFailRequestAndIsCounted() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    tokenFetchService = createTokenFetchService(mockFailingWebClient());
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectNext(cachedToken)
+        .verifyComplete();
+
+    await()
+        .atMost(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> assertThat(backgroundFailureCount("background_refresh_failure")).isOne());
+
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    assertThat(idpCallCount).hasValue(1);
+    assertThat(backgroundFailureCount("background_refresh_failure")).isOne();
+  }
+
+  @Test
+  void failedBackgroundRefresh_isRetriedAfterCooldownExpires() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    AtomicLong tickerNanos = new AtomicLong();
+    tokenFetchService = createTokenFetchService(mockFailingWebClient(), tickerNanos::get);
+
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(idpCallCount).hasValue(1));
+
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    assertThat(idpCallCount).hasValue(1);
+
+    tickerNanos.addAndGet(Duration.ofSeconds(5).plusNanos(1).toNanos());
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(idpCallCount).hasValue(2));
+  }
+
+  @Test
+  void backgroundRefreshCooldownStartsAgainWhenAttemptFinishes() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    AtomicLong tickerNanos = new AtomicLong();
+    Sinks.One<TokenInfo> idpResponse = Sinks.one();
+    tokenFetchService =
+        createTokenFetchService(mockWebClient(idpResponse.asMono()), tickerNanos::get);
+
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(idpCallCount).hasValue(1));
+
+    tickerNanos.addAndGet(Duration.ofSeconds(5).plusNanos(1).toNanos());
+    idpResponse.tryEmitValue(createTokenInfo(20)).orThrow();
+    await()
+        .atMost(Duration.ofSeconds(1))
+        .untilAsserted(() -> assertThat(metricCount("success", "background")).isOne());
+
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    assertThat(idpCallCount).hasValue(1);
+  }
+
+  @Test
+  void successfulBackgroundRefresh_isNotRepeatedBeforeMinimumInterval() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    TokenInfo shortLivedToken = createTokenInfo(20);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    AtomicLong tickerNanos = new AtomicLong();
+    tokenFetchService =
+        createTokenFetchService(mockWebClient(shortLivedToken, Duration.ZERO), tickerNanos::get);
+
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(idpCallCount).hasValue(1));
+
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    assertThat(idpCallCount).hasValue(1);
+
+    tickerNanos.addAndGet(Duration.ofSeconds(5).plusNanos(1).toNanos());
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .block(Duration.ofSeconds(1));
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(idpCallCount).hasValue(2));
+  }
+
+  @Test
+  void failedBackgroundRequestConstruction_doesNotFailRequestAndIsCounted() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    OauthCredentials credentials = new OauthCredentials();
+    credentials.setClientId(CLIENT_ID);
+    credentials.setClientKey("invalid-key");
+    credentials.setGrantType("client_credentials");
+    when(tokenCacheService.generateTokenCacheKey(TOKEN_ENDPOINT, credentials))
+        .thenReturn(TOKEN_CACHE_KEY);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    when(tokenGeneratorService.createJwtTokenFromKey(any(), anyString(), any(), any(), anyString()))
+        .thenThrow(new IllegalArgumentException("Invalid client key"));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithOauthCredentialsObject(TOKEN_ENDPOINT, credentials))
+        .expectNext(cachedToken)
+        .verifyComplete();
+
+    await()
+        .atMost(Duration.ofSeconds(1))
+        .untilAsserted(() -> assertThat(backgroundFailureCount("request_build_failure")).isOne());
+    assertThat(idpCallCount).hasValue(0);
+
+    tokenFetchService
+        .getAccessTokenWithOauthCredentialsObject(TOKEN_ENDPOINT, credentials)
+        .block(Duration.ofSeconds(1));
+    assertThat(backgroundFailureCount("request_build_failure")).isOne();
+  }
+
+  @Test
+  void foregroundRequestConstructionFailurePreservesOriginalError() {
+    OauthCredentials credentials = new OauthCredentials();
+    credentials.setClientId(CLIENT_ID);
+    credentials.setClientKey("invalid-key");
+    credentials.setGrantType("client_credentials");
+    IllegalArgumentException signingFailure = new IllegalArgumentException("Invalid client key");
+    when(tokenCacheService.generateTokenCacheKey(TOKEN_ENDPOINT, credentials))
+        .thenReturn(TOKEN_CACHE_KEY);
+    when(tokenGeneratorService.createJwtTokenFromKey(any(), anyString(), any(), any(), anyString()))
+        .thenThrow(signingFailure);
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithOauthCredentialsObject(TOKEN_ENDPOINT, credentials))
+        .expectErrorMatches(error -> error == signingFailure)
+        .verify();
+  }
+
+  @Test
+  void notServableCachedToken_fetchesReplacement() {
+    TokenInfo cachedToken = createTokenInfo(5);
+    TokenInfo refreshedToken = createTokenInfo(3600);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NOT_SERVABLE));
+    tokenFetchService = createTokenFetchService(mockWebClient(refreshedToken, Duration.ZERO));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectNext(refreshedToken)
+        .verifyComplete();
+
+    assertThat(idpCallCount).hasValue(1);
+  }
+
+  @Test
+  void cancellingTriggeringRequest_doesNotCancelBackgroundRefresh() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    TokenInfo refreshedToken = createTokenInfo(3600);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    tokenFetchService =
+        createTokenFetchService(mockWebClient(refreshedToken, Duration.ofMillis(200)));
+
+    var subscription =
+        tokenFetchService
+            .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+            .flatMap(ignored -> Mono.<TokenInfo>never())
+            .subscribe();
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(idpCallCount).hasValue(1));
+    subscription.dispose();
+
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> verifyTokenSaved(refreshedToken));
+  }
+
+  @Test
+  void cachedTokenIsReturnedBeforeSlowRequestConstructionCompletes() {
+    TokenInfo cachedToken = createTokenInfo(20);
+    OauthCredentials credentials = new OauthCredentials();
+    credentials.setClientId(CLIENT_ID);
+    credentials.setClientKey("client-key");
+    credentials.setGrantType("client_credentials");
+    when(tokenCacheService.generateTokenCacheKey(TOKEN_ENDPOINT, credentials))
+        .thenReturn(TOKEN_CACHE_KEY);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(new TokenLookup(cachedToken, Freshness.NEEDS_REFRESH));
+    CountDownLatch releaseSigning = new CountDownLatch(1);
+    when(tokenGeneratorService.createJwtTokenFromKey(any(), anyString(), any(), any(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              releaseSigning.await();
+              return "client-assertion";
+            });
+
+    Duration elapsed =
+        StepVerifier.create(
+                tokenFetchService.getAccessTokenWithOauthCredentialsObject(
+                    TOKEN_ENDPOINT, credentials))
+            .expectNext(cachedToken)
+            .verifyComplete();
+    releaseSigning.countDown();
+
+    assertThat(elapsed).isLessThan(Duration.ofMillis(250));
+  }
+
+  @Test
+  void overallTimeoutCoversSlowTokenResponse() {
+    TokenInfo replacement = createTokenInfo(3600);
+    tokenFetchService =
+        createTokenFetchService(
+            mockWebClient(replacement, Duration.ofSeconds(2)),
+            Duration.ofMillis(100),
+            Duration.ofMillis(100));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectErrorSatisfies(
+            error ->
+                assertThat(error)
+                    .isInstanceOfSatisfying(
+                        ResponseStatusException.class,
+                        exception -> {
+                          assertThat(exception.getStatusCode().value()).isEqualTo(504);
+                          assertThat(exception.getReason())
+                              .isEqualTo(
+                                  "Timeout occurred while fetching token from " + TOKEN_ENDPOINT);
+                        }))
+        .verify(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void waiterTimeoutDoesNotCancelSharedFetch() {
+    TokenInfo replacement = createTokenInfo(3600);
+    tokenFetchService =
+        createTokenFetchService(
+            mockWebClient(replacement, Duration.ofMillis(300)),
+            Duration.ofSeconds(1),
+            Duration.ofMillis(50));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectErrorSatisfies(
+            error ->
+                assertThat(error)
+                    .isInstanceOfSatisfying(
+                        ResponseStatusException.class,
+                        exception -> {
+                          assertThat(exception.getStatusCode().value()).isEqualTo(504);
+                          assertThat(exception.getReason())
+                              .isEqualTo("Timed out waiting for a token from " + TOKEN_ENDPOINT);
+                        }))
+        .verify(Duration.ofSeconds(1));
+
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> verifyTokenSaved(replacement));
+    assertThat(metricCount("deadline", "foreground")).isOne();
+  }
+
+  @Test
+  void lateSubscriberGetsItsOwnWaitDeadlineWhileSharedFetchContinues() throws InterruptedException {
+    TokenInfo replacement = createTokenInfo(3600);
+    tokenFetchService =
+        createTokenFetchService(
+            mockWebClient(replacement, Duration.ofMillis(400)),
+            Duration.ofSeconds(1),
+            Duration.ofMillis(100));
+
+    tokenFetchService
+        .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+        .subscribe(ignored -> {}, ignored -> {});
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(idpCallCount).hasValue(1));
+    Thread.sleep(150);
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectErrorSatisfies(
+            error ->
+                assertThat(error)
+                    .isInstanceOfSatisfying(
+                        ResponseStatusException.class,
+                        exception -> assertThat(exception.getStatusCode().value()).isEqualTo(504)))
+        .verify(Duration.ofSeconds(1));
+
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> verifyTokenSaved(replacement));
+    assertThat(idpCallCount).hasValue(1);
+  }
+
+  @Test
+  void wrappedConnectionFailure_isRetriedOnceAndMappedToUnauthorized() {
+    WebClientRequestException failure =
+        new WebClientRequestException(
+            new ConnectTimeoutException("Connection timed out"),
+            HttpMethod.POST,
+            URI.create(TOKEN_ENDPOINT),
+            HttpHeaders.EMPTY);
+    tokenFetchService = createTokenFetchService(mockWebClient(Mono.error(failure)));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectErrorSatisfies(
+            error ->
+                assertThat(error)
+                    .isInstanceOfSatisfying(
+                        TokenFetchUnavailableException.class,
+                        exception -> {
+                          assertThat(exception.getStatusCode().value()).isEqualTo(401);
+                          assertThat(exception.getReason()).startsWith("Failed to connect to ");
+                        }))
+        .verify(Duration.ofSeconds(2));
+
+    assertThat(idpCallCount).hasValue(2);
+    assertThat(metricCount("retry_exhausted", "foreground")).isOne();
+    assertThat(
+            meterRegistry
+                .get("jumper.oauth.token.retries")
+                .tag("mode", "foreground")
+                .counter()
+                .count())
+        .isOne();
+  }
+
+  @Test
+  void nonRoutableEndpointWrapsConnectionFailureInWebClientRequestException() {
+    Duration connectTimeout = Duration.ofMillis(100);
+    tokenFetchService =
+        createTokenFetchService(
+            webClientWithConnectTimeout(connectTimeout),
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(10));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                "http://192.0.2.1:81/token", CLIENT_ID, CLIENT_SECRET, null))
+        .expectErrorSatisfies(
+            error -> {
+              assertThat(error).isInstanceOf(TokenFetchUnavailableException.class);
+              assertThat(causeChainContains(error, WebClientRequestException.class)).isTrue();
+              assertThat(
+                      causeChainContains(error, ConnectTimeoutException.class)
+                          || causeChainContains(error, ConnectException.class)
+                          || causeChainContains(error, NoRouteToHostException.class))
+                  .isTrue();
+            })
+        .verify(Duration.ofSeconds(5));
+  }
+
+  @Test
+  void wrappedNoRouteToHostFailure_isMappedToUnauthorized() {
+    WebClientRequestException failure =
+        new WebClientRequestException(
+            new NoRouteToHostException("Network is unreachable"),
+            HttpMethod.POST,
+            URI.create(TOKEN_ENDPOINT),
+            HttpHeaders.EMPTY);
+    tokenFetchService = createTokenFetchService(mockWebClient(Mono.error(failure)));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectErrorSatisfies(
+            error ->
+                assertThat(error)
+                    .isInstanceOfSatisfying(
+                        TokenFetchUnavailableException.class,
+                        exception -> assertThat(exception.getStatusCode().value()).isEqualTo(401)))
+        .verify(Duration.ofSeconds(2));
+  }
+
+  @Test
+  void overallDeadlineBoundsUnresponsiveTokenEndpoint() {
+    Duration overallTimeout = Duration.ofMillis(250);
+    DisposableServer server =
+        HttpServer.create().port(0).handle((request, response) -> Mono.never()).bindNow();
+    try {
+      tokenFetchService =
+          createTokenFetchService(
+              webClientWithConnectTimeout(Duration.ofSeconds(2)), overallTimeout, overallTimeout);
+
+      Duration elapsed =
+          StepVerifier.create(
+                  tokenFetchService.getAccessTokenWithClientCredentials(
+                      "http://localhost:" + server.port() + "/token",
+                      CLIENT_ID,
+                      CLIENT_SECRET,
+                      null))
+              .expectErrorSatisfies(
+                  error ->
+                      assertThat(error)
+                          .isInstanceOfSatisfying(
+                              ResponseStatusException.class,
+                              exception ->
+                                  assertThat(exception.getStatusCode())
+                                      .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)))
+              .verify(Duration.ofSeconds(2));
+
+      assertThat(elapsed).isLessThan(overallTimeout.plusMillis(500));
+    } finally {
+      server.disposeNow();
+    }
+  }
+
+  @Test
+  void missingAccessTokenIsRejectedBeforeCaching() {
+    TokenInfo invalidToken = createTokenInfo(3600);
+    invalidToken.setAccessToken(null);
+    tokenFetchService = createTokenFetchService(mockWebClient(invalidToken, Duration.ZERO));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectErrorSatisfies(
+            error ->
+                assertThat(error)
+                    .isInstanceOfSatisfying(
+                        ResponseStatusException.class,
+                        exception ->
+                            assertThat(exception.getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_ACCEPTABLE)))
+        .verify();
+
+    verify(tokenCacheService, never()).saveTokenIfFetchMatches(anyString(), any(), any());
+  }
+
+  @Test
+  void metricsUseOnlyBoundedTagsAndGaugesReturnToZero() {
+    TokenInfo cachedToken = createTokenInfo(3600);
+    when(tokenCacheService.lookup(TOKEN_CACHE_KEY))
+        .thenReturn(
+            new TokenLookup(null, Freshness.NOT_SERVABLE),
+            new TokenLookup(cachedToken, Freshness.FRESH));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectNextCount(1)
+        .verifyComplete();
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectNext(cachedToken)
+        .verifyComplete();
+
+    assertThat(metricCount("success", "foreground")).isOne();
+    assertThat(metricCount("cache_hit", "foreground")).isOne();
+    assertThat(meterRegistry.get("jumper.oauth.token.fetch.active").gauge().value()).isZero();
+    assertThat(meterRegistry.get("jumper.oauth.token.waiters").gauge().value()).isZero();
+    assertThat(
+            meterRegistry.getMeters().stream()
+                .flatMap(meter -> meter.getId().getTags().stream())
+                .map(tag -> tag.getKey()))
+        .doesNotContain("endpoint", "client", "consumer", "token_key");
+  }
+
+  @Test
+  void gaugesReturnToZeroAfterErrorAndCancelledWaiter() {
+    tokenFetchService =
+        createTokenFetchService(
+            mockWebClient(Mono.error(new IllegalStateException("IDP unavailable"))));
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .expectError()
+        .verify();
+
+    TokenInfo replacement = createTokenInfo(3600);
+    tokenFetchService = createTokenFetchService(mockWebClient(replacement, Duration.ofMillis(200)));
+    var subscription =
+        tokenFetchService
+            .getAccessTokenWithClientCredentials(TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null)
+            .subscribe();
+    await()
+        .atMost(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              assertThat(meterRegistry.get("jumper.oauth.token.fetch.active").gauge().value())
+                  .isOne();
+              assertThat(meterRegistry.get("jumper.oauth.token.waiters").gauge().value()).isOne();
+            });
+    subscription.dispose();
+
+    await()
+        .atMost(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              assertThat(meterRegistry.get("jumper.oauth.token.fetch.active").gauge().value())
+                  .isZero();
+              assertThat(meterRegistry.get("jumper.oauth.token.waiters").gauge().value()).isZero();
+            });
+  }
+
+  @Test
+  void errorBodyRead_isTruncatedToConfiguredByteLimit() {
+    byte[] body = "x".repeat(10_000).getBytes(StandardCharsets.UTF_8);
+    ClientResponse response =
+        ClientResponse.create(HttpStatus.BAD_REQUEST)
+            .body(
+                reactor.core.publisher.Flux.just(
+                    DefaultDataBufferFactory.sharedInstance.wrap(body)))
+            .build();
+
+    StepVerifier.create(tokenFetchService.readErrorBody(response))
+        .assertNext(value -> assertThat(value.getBytes(StandardCharsets.UTF_8)).hasSize(8 * 1024))
+        .verifyComplete();
+  }
+
+  @Test
+  void errorBodyReadFailure_preservesOriginalUpstreamError() {
+    ClientResponse response =
+        ClientResponse.create(HttpStatus.BAD_REQUEST)
+            .body(reactor.core.publisher.Flux.error(new IllegalStateException("body read failed")))
+            .build();
+
+    Logger logger = (Logger) LoggerFactory.getLogger(TokenFetchService.class);
+    Level previousLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
+    try {
+      StepVerifier.create(
+              tokenFetchService.handleIdpError(response, TOKEN_ENDPOINT, TOKEN_CACHE_KEY))
+          .assertNext(
+              error ->
+                  assertThat(error)
+                      .isInstanceOfSatisfying(
+                          ResponseStatusException.class,
+                          exception -> {
+                            assertThat(exception.getStatusCode().value()).isEqualTo(401);
+                            assertThat(exception.getReason())
+                                .contains("original status: 400 BAD_REQUEST");
+                          }))
+          .verifyComplete();
+    } finally {
+      logger.setLevel(previousLevel);
+    }
+  }
+
   // --- helpers ---
+
+  private TokenFetchService createTokenFetchService(WebClient webClient) {
+    return createTokenFetchService(webClient, Duration.ofSeconds(5), Duration.ofSeconds(5));
+  }
+
+  private TokenFetchService createTokenFetchService(WebClient webClient, Ticker ticker) {
+    return createTokenFetchService(webClient, Duration.ofSeconds(5), Duration.ofSeconds(5), ticker);
+  }
+
+  private TokenFetchService createTokenFetchService(
+      WebClient webClient, Duration overallTimeout, Duration requestWaitTimeout) {
+    return createTokenFetchService(
+        webClient, overallTimeout, requestWaitTimeout, Ticker.systemTicker());
+  }
+
+  private TokenFetchService createTokenFetchService(
+      WebClient webClient, Duration overallTimeout, Duration requestWaitTimeout, Ticker ticker) {
+    return new TokenFetchService(
+        webClient,
+        tokenCacheService,
+        tokenGeneratorService,
+        tokenFetchMetrics,
+        new OauthTokenFetchProperties(
+            Duration.ofSeconds(2),
+            overallTimeout,
+            requestWaitTimeout,
+            1,
+            Duration.ofMillis(200),
+            Duration.ofSeconds(1),
+            DataSize.ofKilobytes(8),
+            Duration.ofSeconds(30),
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(5)),
+        ticker);
+  }
+
+  private double backgroundFailureCount(String outcome) {
+    return metricCount(outcome, "background");
+  }
+
+  private WebClient webClientWithConnectTimeout(Duration connectTimeout) {
+    HttpClient httpClient =
+        HttpClient.create()
+            .option(
+                ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(connectTimeout.toMillis()));
+    return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+  }
+
+  private boolean causeChainContains(Throwable error, Class<? extends Throwable> type) {
+    Throwable current = error;
+    while (current != null) {
+      if (type.isInstance(current)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private double metricCount(String outcome, String mode) {
+    return meterRegistry
+        .get("jumper.oauth.token.fetch")
+        .tags("outcome", outcome, "mode", mode)
+        .counter()
+        .count();
+  }
 
   private TokenInfo createTokenInfo(int expiresInSeconds) {
     TokenInfo tokenInfo = new TokenInfo();
@@ -259,6 +1017,13 @@ class TokenFetchServiceTest {
 
   @SuppressWarnings("unchecked")
   private WebClient mockWebClient(TokenInfo responseToken, Duration delay) {
+    Mono<TokenInfo> response =
+        delay.isZero() ? Mono.just(responseToken) : Mono.just(responseToken).delayElement(delay);
+    return mockWebClient(response);
+  }
+
+  @SuppressWarnings("unchecked")
+  private WebClient mockWebClient(Mono<TokenInfo> response) {
     WebClient webClient = mock(WebClient.class);
     WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
     WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
@@ -276,9 +1041,7 @@ class TokenFetchServiceTest {
             Mono.defer(
                 () -> {
                   idpCallCount.incrementAndGet();
-                  return delay.isZero()
-                      ? Mono.just(responseToken)
-                      : Mono.just(responseToken).delayElement(delay);
+                  return response;
                 }));
 
     return webClient;
@@ -311,5 +1074,35 @@ class TokenFetchServiceTest {
                 }));
 
     return webClient;
+  }
+
+  @SuppressWarnings("unchecked")
+  private WebClient mockFailingWebClient() {
+    WebClient webClient = mock(WebClient.class);
+    WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+    WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+    WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+    WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+    when(webClient.post()).thenReturn(requestBodyUriSpec);
+    when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+    when(requestBodySpec.headers(any())).thenReturn(requestBodySpec);
+    when(requestBodySpec.body(any())).thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+    when(responseSpec.bodyToMono(TokenInfo.class))
+        .thenReturn(
+            Mono.defer(
+                () -> {
+                  idpCallCount.incrementAndGet();
+                  return Mono.error(new IllegalStateException("IDP unavailable"));
+                }));
+
+    return webClient;
+  }
+
+  private void verifyTokenSaved(TokenInfo refreshedToken) {
+    verify(tokenCacheService)
+        .saveTokenIfFetchMatches(eq(TOKEN_CACHE_KEY), any(), same(refreshedToken));
   }
 }

--- a/src/test/java/jumper/service/TokenFetchServiceTest.java
+++ b/src/test/java/jumper/service/TokenFetchServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.*;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.github.benmanes.caffeine.cache.Ticker;
+import io.jsonwebtoken.Jwts;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ConnectTimeoutException;
@@ -21,6 +22,8 @@ import java.net.NoRouteToHostException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -129,6 +132,70 @@ class TokenFetchServiceTest {
 
     verify(tokenCacheService)
         .saveTokenIfFetchMatches(eq(TOKEN_CACHE_KEY), any(), any(TokenInfo.class));
+  }
+
+  @Test
+  void tokenWithoutExpiresIn_usesAccessTokenExpiration() {
+    Date tokenExpiration = jwtDate(Instant.now().plusSeconds(300));
+    TokenInfo responseToken = tokenWithoutExpiresIn(jwtExpiringAt(tokenExpiration));
+    tokenFetchService = createTokenFetchService(mockWebClient(responseToken, Duration.ZERO));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .assertNext(token -> assertThat(token.getExpiration()).isEqualTo(tokenExpiration))
+        .verifyComplete();
+  }
+
+  @Test
+  void tokenWithoutExpiresIn_usesExpiredAccessTokenExpiration() {
+    Date tokenExpiration = jwtDate(Instant.now().minusSeconds(7200));
+    TokenInfo responseToken = tokenWithoutExpiresIn(jwtExpiringAt(tokenExpiration));
+    tokenFetchService = createTokenFetchService(mockWebClient(responseToken, Duration.ZERO));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .assertNext(token -> assertThat(token.getExpiration()).isEqualTo(tokenExpiration))
+        .verifyComplete();
+  }
+
+  @Test
+  void expiresInTakesPrecedenceOverAccessTokenExpiration() {
+    TokenInfo responseToken = tokenWithoutExpiresIn(jwtExpiringAt(Instant.now().plusSeconds(300)));
+    responseToken.setExpiresIn(120);
+    Date responseExpiration = responseToken.getExpiration();
+    tokenFetchService = createTokenFetchService(mockWebClient(responseToken, Duration.ZERO));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .assertNext(token -> assertThat(token.getExpiration()).isEqualTo(responseExpiration))
+        .verifyComplete();
+  }
+
+  @Test
+  void jwtWithoutExpiration_keepsDefaultCacheLifetime() {
+    TokenInfo responseToken = tokenWithoutExpiresIn(Jwts.builder().subject("subject").compact());
+    tokenFetchService = createTokenFetchService(mockWebClient(responseToken, Duration.ZERO));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .assertNext(token -> assertThat(token.getExpiration()).isNull())
+        .verifyComplete();
+  }
+
+  @Test
+  void opaqueTokenWithoutExpiresIn_keepsDefaultCacheLifetime() {
+    TokenInfo responseToken = tokenWithoutExpiresIn("opaque-access-token");
+    tokenFetchService = createTokenFetchService(mockWebClient(responseToken, Duration.ZERO));
+
+    StepVerifier.create(
+            tokenFetchService.getAccessTokenWithClientCredentials(
+                TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET, null))
+        .assertNext(token -> assertThat(token.getExpiration()).isNull())
+        .verifyComplete();
   }
 
   @Test
@@ -1013,6 +1080,25 @@ class TokenFetchServiceTest {
     tokenInfo.setExpiresIn(expiresInSeconds);
     tokenInfo.setTokenType("Bearer");
     return tokenInfo;
+  }
+
+  private TokenInfo tokenWithoutExpiresIn(String accessToken) {
+    TokenInfo tokenInfo = new TokenInfo();
+    tokenInfo.setAccessToken(accessToken);
+    tokenInfo.setTokenType("Bearer");
+    return tokenInfo;
+  }
+
+  private String jwtExpiringAt(Instant expiration) {
+    return jwtExpiringAt(jwtDate(expiration));
+  }
+
+  private String jwtExpiringAt(Date expiration) {
+    return Jwts.builder().expiration(expiration).compact();
+  }
+
+  private Date jwtDate(Instant instant) {
+    return Date.from(Instant.ofEpochSecond(instant.getEpochSecond()));
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/resources/features/errorResponse.feature
+++ b/src/test/resources/features/errorResponse.feature
@@ -136,7 +136,7 @@ Feature: proper error message returned based on conditions
       | jumper_config | http_element  | api_receiver_code | msg_content | error | error_code |
     # default
       | "default" | body | 406 |  "Empty response while fetching token from http://localhost:1081/external" | "Not Acceptable" | 406 |
-      | "default" | header | 406 | "Failed while fetching token from http://localhost:1081/external: Content type 'application/octet-stream' not supported for TokenInfo" | "Not Acceptable" | 406 |
+      | "default" | header | 406 | "Identity provider returned an invalid token response from http://localhost:1081/external" | "Not Acceptable" | 406 |
       | "default" | both  | 406 | "Empty response while fetching token from http://localhost:1081/external" | "Not Acceptable" | 406 |
 
 ################ external IDP - timeout connection ################
@@ -148,7 +148,7 @@ Feature: proper error message returned based on conditions
     And API provider set to respond with a 200 status code
     When consumer calls the proxy route with idp timeout
     And API consumer receives a 504 status code
-    And error response contains msg "Timeout occurred while fetching token from http://localhost:1081/external" error "Gateway Timeout" status 504
+    And error response contains msg "Timed out waiting for a token from http://localhost:1081/external" error "Gateway Timeout" status 504
 
 ################ external IDP - drop connection ################
   Scenario: external IDP drop connection

--- a/src/test/resources/features/tokenCaching.feature
+++ b/src/test/resources/features/tokenCaching.feature
@@ -70,3 +70,21 @@ Feature: Token caching for external OAuth tokens
     When consumer calls the proxy route
     Then API Provider receives authorization ExternalConfigured
     And API consumer receives a 200 status code
+
+  Scenario: Cached token is served during the minimum background refresh interval
+    Given RealRoute headers are set
+    And oauth tokenEndpoint set
+    And jumperConfig oauth "consumer grant_type client_credentials" set
+    And IDP set to provide a short-lived token then fail refreshes
+    And API provider set to respond with a 200 status code
+    When consumer calls the proxy route
+    Then API Provider receives authorization ExternalConfigured
+    And API consumer receives a 200 status code
+    When consumer calls the proxy route again
+    Then API Provider receives authorization ExternalConfigured
+    And API consumer receives a 200 status code
+    And IDP token endpoint eventually receives exactly 2 calls
+    When consumer calls the proxy route again
+    Then API Provider receives authorization ExternalConfigured
+    And API consumer receives a 200 status code
+    And IDP token endpoint call count remains exactly 2


### PR DESCRIPTION
## Functional changes

- add validated, environment-overridable OAuth token-fetch timeouts, retry limits, backoff, body limits, refresh thresholds, and minimum refresh intervals
- reduce the effective OAuth connect-timeout default from 10 seconds to 2 seconds and apply a new 10-second overall fetch deadline plus a 4-second per-request wait deadline
- classify wrapped connection failures across the full cause chain and retry them at most once with jitter
- preserve the existing consumer response contract: identity-provider and exhausted connection errors remain `401 Unauthorized`, malformed or empty token responses remain `406 Not Acceptable`, and timeouts remain `504 Gateway Timeout`
- derive cache expiration from the JWT `exp` claim when `expires_in` is absent, while preserving `expires_in` precedence and the configured cache lifetime for opaque or unparseable tokens
- proactively refresh tokens while continuing to serve tokens that remain safe to forward
- enforce a per-key minimum background-refresh interval after each attempt, preventing continuous refresh loops for short-lived tokens
- coalesce concurrent foreground and background fetches and make authentication-failure eviction win over older fetches through atomic exact-publisher identity checks
- hash all credential and authorization-identity fields into cache and active-fetch keys, preventing password-grant users that share client credentials from sharing tokens; request transport form does not split equivalent identities
- consume or release identity-provider error bodies in-chain with bounded DEBUG diagnostics
- expose low-cardinality fetch outcomes, retries, active-fetch gauges, and waiter gauges, including per-waiter deadline outcomes
- remove mutable singleton response-header state from the error handler, preventing concurrent response-header cross-contamination

## Compatibility

This change preserves the existing auth-related HTTP status codes. The effective OAuth connect-timeout default changes from 10 seconds to 2 seconds. The new overall fetch deadline defaults to 10 seconds, while each request waits at most 4 seconds for a shared fetch. Cache keys change in memory, so each pod starts with a cold token cache after deployment and repopulates it on demand.

## Verification

- focused OAuth resilience suite: 53 tests passed
- `./mvnw clean test`: 431 tests passed, 0 failures/errors
- Cucumber runner: 2 test runners passed
- strict OpenSpec validation passed
- `git diff --check` passed

The latest local validation attempt was blocked before compilation because Maven Central timed out while resolving Spring Boot 4.1.0.

## Deferred follow-ups and accepted review notes

- add a per-attempt response timeout only after measured identity-provider p99 data is available; timeout-driven retries must exclude or explicitly accept risks for rotating refresh tokens
- keep identity-provider error bodies DEBUG-only to avoid exposing credential-related payloads in normal logs
- a failed background refresh records both its underlying fetch outcome and aggregate `background_refresh_failure`
- the `mode` metric identifies the creator of a shared fetch rather than every waiter that joins it
- request-level bulkheads, per-host circuit breakers, and finite OAuth pool bounds remain follow-up work sized from the new metrics