### PR TITLE
ci: add opt-in lightweight git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Contributing
+
+All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Build and test
+
+Jumper requires Java 25. Use the Maven wrapper so the build uses the repository's
+Maven version:
+
+```bash
+./mvnw clean package
+```
+
+The test suite uses Docker through Testcontainers and pulls its test images from
+the network. Start Docker before running the build, allow Maven and Docker network
+access, and leave local ports `1080`, `1081`, and `1082` available for the
+Cucumber WireMock servers. Testcontainers and Spring Boot also allocate dynamic
+host ports.
+
+Run one test with a clean build directory:
+
+```bash
+./mvnw clean test -Dtest=TestClassName
+```
+
+See [Building](README.md#building) for application and OCI image build commands.
+
+## Git hooks
+
+The repository includes an optional [Lefthook](https://lefthook.dev/)
+configuration. Install the hooks once in each clone:
+
+```bash
+lefthook install
+```
+
+The installed hook wrapper reports a missing Lefthook binary instead of silently
+skipping checks. This does not install hooks or enforce Lefthook in clones where
+you have not run `lefthook install`. CI remains the authoritative validation gate.
+
+Install these tools before using the hooks:
+
+- [Lefthook](https://lefthook.dev/#how-to-install-lefthook) 2.0.4 or newer
+- [Gitleaks](https://github.com/gitleaks/gitleaks#installing) 8.20.0 or newer
+- [committed](https://github.com/crate-ci/committed#install)
+- [REUSE](https://github.com/fsfe/reuse-tool#install) 4.0.0 or newer
+- Java 25
+
+The hooks run these read-only checks:
+
+| Hook | Check |
+| --- | --- |
+| `pre-commit` | Run Spotless when staged Java or Maven build inputs change, run `reuse lint` over the whole repository, and scan staged content with Gitleaks. These jobs run in parallel. |
+| `commit-msg` | Validate the commit message with `committed --commit-file <path>` and require a lowercase type, except during merges and rebases. |
+| `pre-push` | Always check formatting without running the full build or test suite. |
+
+Spotless checks all configured Java sources even though staged paths decide
+whether the pre-commit job runs. The pre-push hook repeats the check to cover
+changes introduced without a pre-commit hook, such as rebases and cherry-picks.
+Neither hook rewrites source files. Gitleaks uses `gitleaks git --staged`, so it
+scans staged content rather than the full history or unstaged working tree. Do
+not add broad secret allowlists. Any exclusion must address a demonstrated false
+positive, remain as narrow as possible, and receive review. If a
+`.gitleaks.toml` becomes necessary, retain the default rules with
+`[extend] useDefault = true`.
+
+To bypass an installed hook for one command, set `LEFTHOOK=0` or use Git's
+`--no-verify` option:
+
+```bash
+LEFTHOOK=0 git commit ...
+git commit --no-verify ...
+LEFTHOOK=0 git push ...
+git push --no-verify ...
+```
+
+Use a bypass only when necessary. CI still runs its required checks.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/). The accepted
+types match [`release.config.js`](release.config.js):
+
+`feat`, `fix`, `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`,
+`style`, and `test`.
+
+Types must be lowercase. Scopes are optional and unrestricted. Both the `!`
+marker and a `BREAKING CHANGE:` footer trigger a major release for every accepted
+type. Merge commits skip local message validation. Rewrite Git's generated revert
+subject as `revert: <subject>` so semantic-release recognizes it. The policy does
+not restrict subject capitalization, punctuation, imperative mood, or line
+length beyond the Conventional Commits structure.
+
+## Releases
+
+See [Releases](README.md#releases) for branch roles and the automatic release
+process. Because every accepted commit type can publish a release, choose the
+type that describes the change.

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Once you have that, refer to the [Configuration](#configuration) section to find
 
 ## Contributing
 
-This project has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) in version 2.1 as our code of conduct. Please see the details in our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). All contributors must abide by the code of conduct.
-
-By participating in this project, you agree to abide by its Code of Conduct at all times.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for build and test prerequisites, optional
+local Git hooks, and the commit message policy. All contributors must follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Releases
 

--- a/committed.toml
+++ b/committed.toml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Conventional Commits policy for semantic-release (release.config.js).
+style = "conventional"
+
+allowed_types = [
+  "feat",
+  "fix",
+  "build",
+  "chore",
+  "ci",
+  "docs",
+  "perf",
+  "refactor",
+  "revert",
+  "style",
+  "test",
+]
+
+# committed compares allowed types case-insensitively. lefthook.yml separately
+# requires the type prefix to use the lowercase spelling listed above.
+
+# semantic-release does not restrict optional scopes or commit prose.
+# Zero disables committed's subject and line length checks.
+subject_length = 0
+line_length = 0
+hard_line_length = 0
+subject_capitalized = false
+subject_not_punctuated = false
+imperative_subject = false

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Install these optional local hooks once per clone with: lefthook install
+# CI remains the authoritative validation gate.
+
+# After hooks are installed, fail visibly when the lefthook binary is missing.
+# This setting does not install hooks or require contributors to opt in.
+assert_lefthook_installed: true
+min_version: 2.0.4
+glob_matcher: doublestar
+
+pre-commit:
+  parallel: true
+  jobs:
+    # Mirrors the formatting check in .github/workflows/build.yml. Spotless must
+    # inspect every configured Java source, not only the staged file list.
+    - name: spotless
+      glob: "{src/main/java/**/*.java,src/test/java/**/*.java,pom.xml,.mvn/**/*,mvnw,mvnw.cmd}"
+      run: ./mvnw -B com.diffplug.spotless:spotless-maven-plugin:check
+      fail_text: "Spotless failed (or Java 25/Maven setup is unavailable; see CONTRIBUTING.md)."
+
+    # Mirrors .github/workflows/reuse.yml and checks the whole repository.
+    - name: reuse
+      run: reuse lint
+      fail_text: "REUSE/SPDX validation failed (or reuse is missing; see CONTRIBUTING.md)."
+
+    # Scan staged content only. Keep exclusions narrow and reviewed.
+    - name: gitleaks
+      run: gitleaks git --staged --redact --no-banner --exit-code=1
+      fail_text: "Gitleaks found a possible staged secret or failed to run (requires Gitleaks 8.20.0+; see CONTRIBUTING.md)."
+
+commit-msg:
+  jobs:
+    - name: committed
+      skip:
+        - merge
+        - rebase
+      run: committed --commit-file "{1}"
+      fail_text: |
+        Commit message must follow Conventional Commits.
+        Allowed types: feat, fix, build, chore, ci, docs, perf, refactor, revert, style, test
+        See CONTRIBUTING.md and committed.toml.
+
+    - name: lowercase-type
+      skip:
+        - merge
+        - rebase
+      run: >-
+        head -n 1 "{1}" |
+        grep -Eq '^(feat|fix|build|chore|ci|docs|perf|refactor|revert|style|test)(\([^)]*\))?!?: '
+      fail_text: "Commit type must be lowercase; see CONTRIBUTING.md."
+
+pre-push:
+  jobs:
+    # Check formatting without running the full build or test suite.
+    - name: spotless
+      run: ./mvnw -B com.diffplug.spotless:spotless-maven-plugin:check
+      fail_text: "Spotless failed (or Java 25/Maven setup is unavailable; see CONTRIBUTING.md)."

--- a/release.config.js
+++ b/release.config.js
@@ -15,7 +15,9 @@ module.exports = {
     [
       '@semantic-release/commit-analyzer',
       {
+        preset: 'conventionalcommits',
         releaseRules: [
+          { breaking: true, release: 'major' },
           { type: 'build', release: 'patch' },
           { type: 'chore', release: 'patch' },
           { type: 'ci', release: 'patch' },


### PR DESCRIPTION
## Summary

- add opt-in Lefthook checks for Java formatting, repository licensing, staged secrets, and Conventional Commits
- require Gitleaks 8.20.0 or newer for staged-only scanning and keep pre-push limited to Spotless
- add contributor documentation for hook setup, prerequisites, bypasses, and commit policy

Hooks remain optional through `lefthook install`, and CI remains the authoritative validation gate. Pre-commit runs Spotless for relevant staged Java/build inputs, whole-repository `reuse lint`, and staged Gitleaks in parallel. Commit-msg runs `committed --commit-file {1}` and requires a lowercase type so accepted commits match the semantic-release rules. Pre-push runs Spotless only; contributors and CI remain responsible for the full build and test suite.