### PR TITLE
feat: support a separate management port

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ For production deployments, refer to the jumper section in the Gateway Helm char
 
 For local development and testing, Jumper uses Spring Boot's configuration mechanism with properties defined in [`application.yml`](src/main/resources/application.yml). The application can be configured through environment variables that are referenced in this configuration file.
 
+The application and Spring management endpoints use the same listener by default. Set
+`JUMPER_MANAGEMENT_PORT` to expose management endpoints such as `/actuator/health` on a separate
+listener. Kubernetes-compatible `/livez` and `/readyz` probes remain available on the main
+application listener whether management endpoints use the same listener or a separate one.
+
+| Environment variable | Purpose | Default |
+| --- | --- | --- |
+| `JUMPER_PORT` | Main application listener port | `8080` |
+| `JUMPER_MANAGEMENT_PORT` | Spring management listener port | Unset; shares the application listener |
+
 For additional standard Spring Boot properties, refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/appendix/application-properties/index.html).
 
 ## Usage Scenarios

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,13 +12,16 @@ server:
   forward-headers-strategy: none
 
 management:
+  server:
+    port: ${JUMPER_MANAGEMENT_PORT:}
   health:
     redis:
       enabled: false
   endpoint:
     health:
       probes:
-        enabled: true #healthcheck probes, liveness and readiness
+        enabled: true # healthcheck probes, liveness and readiness
+        add-additional-paths: true
       group:
         readiness:
           include: readinessState

--- a/src/test/java/jumper/config/ApplicationConfigurationTest.java
+++ b/src/test/java/jumper/config/ApplicationConfigurationTest.java
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class ApplicationConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner().withInitializer(new ConfigDataApplicationContextInitializer());
+
+  @Test
+  void managementPortIsUnsetByDefault() {
+    contextRunner.run(
+        context -> {
+          var environment = context.getEnvironment();
+
+          assertThat(environment.getProperty("server.port", Integer.class)).isEqualTo(8080);
+          assertThat(environment.getProperty("management.server.port", Integer.class)).isNull();
+          assertThat(ManagementPortType.get(environment)).isEqualTo(ManagementPortType.SAME);
+          assertThat(
+                  environment.getProperty(
+                      "management.endpoint.health.probes.add-additional-paths", Boolean.class))
+              .isTrue();
+        });
+  }
+
+  @Test
+  void managementPortStaysUnsetWhenApplicationPortIsConfigured() {
+    contextRunner
+        .withPropertyValues("JUMPER_PORT=8181")
+        .run(
+            context -> {
+              var environment = context.getEnvironment();
+
+              assertThat(environment.getProperty("server.port", Integer.class)).isEqualTo(8181);
+              assertThat(environment.getProperty("management.server.port", Integer.class)).isNull();
+              assertThat(ManagementPortType.get(environment)).isEqualTo(ManagementPortType.SAME);
+            });
+  }
+
+  @Test
+  void managementSharesApplicationListenerWhenServerPortIsOverridden() {
+    contextRunner
+        .withPropertyValues("server.port=9000")
+        .run(
+            context -> {
+              var environment = context.getEnvironment();
+
+              assertThat(environment.getProperty("server.port", Integer.class)).isEqualTo(9000);
+              assertThat(environment.getProperty("management.server.port", Integer.class)).isNull();
+              assertThat(ManagementPortType.get(environment)).isEqualTo(ManagementPortType.SAME);
+            });
+  }
+
+  @Test
+  void managementPortCanBeConfiguredSeparately() {
+    contextRunner
+        .withPropertyValues("JUMPER_PORT=8181", "JUMPER_MANAGEMENT_PORT=9090")
+        .run(
+            context -> {
+              var environment = context.getEnvironment();
+
+              assertThat(environment.getProperty("server.port", Integer.class)).isEqualTo(8181);
+              assertThat(environment.getProperty("management.server.port", Integer.class))
+                  .isEqualTo(9090);
+            });
+  }
+
+  @Test
+  void managementPortCanBeConfiguredWhenApplicationPortIsAbsent() {
+    contextRunner
+        .withPropertyValues("JUMPER_MANAGEMENT_PORT=9090")
+        .run(
+            context -> {
+              var environment = context.getEnvironment();
+
+              assertThat(environment.getProperty("server.port", Integer.class)).isEqualTo(8080);
+              assertThat(environment.getProperty("management.server.port", Integer.class))
+                  .isEqualTo(9090);
+            });
+  }
+}

--- a/src/test/java/jumper/config/DefaultHealthProbeIntegrationTest.java
+++ b/src/test/java/jumper/config/DefaultHealthProbeIntegrationTest.java
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient
+class DefaultHealthProbeIntegrationTest {
+
+  @Autowired private WebTestClient webTestClient;
+
+  @Test
+  void healthEndpointAndProbeAliasesUseApplicationListener() {
+    webTestClient.get().uri("/actuator/health").exchange().expectStatus().isOk();
+    webTestClient.get().uri("/actuator/health/liveness").exchange().expectStatus().isOk();
+    webTestClient.get().uri("/actuator/health/readiness").exchange().expectStatus().isOk();
+    webTestClient.get().uri("/livez").exchange().expectStatus().isOk();
+    webTestClient.get().uri("/readyz").exchange().expectStatus().isOk();
+  }
+}

--- a/src/test/java/jumper/config/SeparateHealthProbeIntegrationTest.java
+++ b/src/test/java/jumper/config/SeparateHealthProbeIntegrationTest.java
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jumper.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = "JUMPER_MANAGEMENT_PORT=0")
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient
+class SeparateHealthProbeIntegrationTest {
+
+  @Autowired private WebTestClient webTestClient;
+
+  @Value("${local.management.port}")
+  private int managementPort;
+
+  @Test
+  void healthProbeAliasesAreAvailableOnApplicationListener() {
+    WebTestClient managementWebTestClient =
+        WebTestClient.bindToServer().baseUrl("http://localhost:" + managementPort).build();
+
+    managementWebTestClient.get().uri("/actuator/health").exchange().expectStatus().isOk();
+    managementWebTestClient.get().uri("/actuator/health/liveness").exchange().expectStatus().isOk();
+    managementWebTestClient
+        .get()
+        .uri("/actuator/health/readiness")
+        .exchange()
+        .expectStatus()
+        .isOk();
+    managementWebTestClient.get().uri("/livez").exchange().expectStatus().isNotFound();
+    managementWebTestClient.get().uri("/readyz").exchange().expectStatus().isNotFound();
+
+    webTestClient.get().uri("/livez").exchange().expectStatus().isOk();
+    webTestClient.get().uri("/readyz").exchange().expectStatus().isOk();
+    webTestClient.get().uri("/actuator/health").exchange().expectStatus().isNotFound();
+    webTestClient.get().uri("/actuator/health/liveness").exchange().expectStatus().isNotFound();
+    webTestClient.get().uri("/actuator/health/readiness").exchange().expectStatus().isNotFound();
+  }
+}


### PR DESCRIPTION
## Summary

- allow Spring management endpoints to use a dedicated listener
- keep `/livez` and `/readyz` on the application listener
- document the new `JUMPER_MANAGEMENT_PORT` setting
- test shared and separate listener configurations

## Validation

- `./mvnw clean test`
- `./mvnw spotless:check`
- `reuse lint`
- `git diff --check`