### PR TITLE
ci: add Artifactory retention for feature images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,8 @@ jobs:
           # No credentials are passed: Jib reads the Docker config written by the registry
           # login step above, which this job also needs for cosign.
           mvn -B -U package -DskipTests jib:build \
-            -Djib.to.image="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+            -Djib.to.image="${IMAGE_REPOSITORY}:${IMAGE_TAG}" \
+            -Djib.container.labels=expiration=3months
           echo "digest=$(cat target/jib-image.digest)" >> "${GITHUB_OUTPUT}"
       - name: Scan preview image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0


### PR DESCRIPTION
## Summary

- add `expiration=3months` to pull request preview images
- omit the expiration label from `main` and `next` release images
- keep Git tag images indefinitely

Artifactory exposes this image label as `docker.label.expiration`.

## Motivation

Preview images become obsolete after their branches merge or close. Automatic retention removes these unused images, reduces storage use, and keeps repositories manageable.

Release images from `main` and `next` remain available indefinitely for deployments and rollback.

## Documentation

[Artifactory Repository Cleanup Policy](https://docs.devops.telekom.de/docs/developer-tools/mcicd/Artifactory/artifactory/repository-cleanup-policy/#setting-the-property-during-artifact-push)

## Validation

- CI YAML parsed successfully
- GitHub workflow passed `actionlint`
- release behavior for `main` and `next` was verified